### PR TITLE
fix: Railway main 브랜치 배포 활성화

### DIFF
--- a/.github/workflows/railway-deploy.yml
+++ b/.github/workflows/railway-deploy.yml
@@ -1,37 +1,37 @@
 name: Railway Backend Deploy
 
+# Railway: backend/ 서비스는 GitHub 연동 + backend/railway.toml 의
+# [git] deploymentEnabled 로 브랜치별 자동 배포가 결정됩니다. main 푸시로
+# PR 머지가 반영되려면 deploymentEnabled.main=true 이어야 합니다.
+# 아래 job은 (선택) 수동 웹훅 보조용 — 시크릿이 없으면 no-op.
+
 on:
   push:
-    branches: [ backend ]
-  workflow_dispatch:  # 수동 트리거 가능
+    branches: [ main, backend ]
+    paths:
+      - "backend/**"
+  workflow_dispatch:
 
 jobs:
   notify-railway:
     runs-on: ubuntu-latest
-    
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-    
-    - name: Notify Railway Deployment
-      run: |
-        echo "Backend branch updated. Railway should auto-deploy via webhook."
-        echo "Commit: ${{ github.sha }}"
-        echo "Branch: ${{ github.ref_name }}"
-        echo "Repository: ${{ github.repository }}"
-        
-        # Railway 웹훅 트리거 (Railway 대시보드에서 설정된 경우)
-        curl -X POST \
-          -H "Content-Type: application/json" \
-          -d '{
-            "ref": "${{ github.ref }}",
-            "repository": {
-              "full_name": "${{ github.repository }}",
-              "clone_url": "${{ github.server_url }}/${{ github.repository }}.git"
-            },
-            "head_commit": {
-              "id": "${{ github.sha }}",
-              "message": "${{ github.event.head_commit.message }}"
-            }
-          }' \
-          "${{ secrets.RAILWAY_WEBHOOK_URL }}" || echo "Webhook not configured, Railway auto-deploy should handle this"
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Log deploy context
+        run: |
+          echo "Branch: $GITHUB_REF_NAME | SHA: $GITHUB_SHA | Repo: $GITHUB_REPOSITORY"
+
+      - name: Optional webhook to Railway
+        env:
+          RAILWAY_WEBHOOK_URL: ${{ secrets.RAILWAY_WEBHOOK_URL }}
+        run: |
+          if [ -z "${RAILWAY_WEBHOOK_URL}" ]; then
+            echo "RAILWAY_WEBHOOK_URL not set; relying on Railway GitHub app integration (recommended)."
+            exit 0
+          fi
+          curl -fsS -X POST \
+            -H "Content-Type: application/json" \
+            -d "{\"ref\":\"${{ github.ref }}\",\"repository\":{\"full_name\":\"${{ github.repository }}\"},\"head_commit\":{\"id\":\"${{ github.sha }}\"}}" \
+            "$RAILWAY_WEBHOOK_URL"

--- a/backend/railway.json
+++ b/backend/railway.json
@@ -12,8 +12,8 @@
     },
     "git": {
         "deploymentEnabled": {
+            "main": true,
             "backend": true,
-            "main": false,
             "frontend": false
         }
     }

--- a/backend/railway.toml
+++ b/backend/railway.toml
@@ -9,6 +9,8 @@ restartPolicyType = "ON_FAILURE"
 restartPolicyMaxRetries = 10
 
 [git]
+# PR 및 프로덕션은 main 기준이므로 main에서 자동 배포 허용
+# legacy 실험용 backend 브랜치도 유지
+deploymentEnabled.main = true
 deploymentEnabled.backend = true
-deploymentEnabled.main = false
 deploymentEnabled.frontend = false


### PR DESCRIPTION
## 원인
- `backend/railway.toml` / `railway.json` 에서 `deploymentEnabled.main = false` 로 설정되어 `main` 푸시(PR 머지) 시 Railway 자동 배포가 발생하지 않았습니다.
- `.github/workflows/railway-deploy.yml` 의 `RAILWAY_WEBHOOK_URL` 이 비어 있을 때 빈 URL로 `curl` 이 호출되어 의미 없는 오류가 났습니다.

## 변경
- `main` 및 `backend` 브랜치 모두에서 `backend/**` 변경 시 배포 구성이 일치하도록 `deploymentEnabled.main=true` 로 수정했습니다.
- 웹훅은 시크릿이 있을 때만 호출하고, 없으면 Railway GitHub 연동에만 의존하도록 했습니다.

Made with [Cursor](https://cursor.com)