### PR TITLE
docs(pt): PT 모바일 재출발 기획·출시 문서

### DIFF
--- a/docs/AI_RECOMMENDATION_PROMPT.md
+++ b/docs/AI_RECOMMENDATION_PROMPT.md
@@ -1,0 +1,202 @@
+# Grok 일일 WOD 추천 — 입력 컨텍스트 + 프롬프트 초안
+
+## 0. 사용 모델
+
+- 모델: `grok-4-1-fast-non-reasoning` (환경변수 `XAI_MODEL`로 오버라이드).
+- 호출 패턴: [backend/routes/burnfat_ai.py](../backend/routes/burnfat_ai.py)의 `_call_grok` 헬퍼 그대로 차용 (OpenAI 호환 chat/completions, Bearer token).
+- 비용 통제: `(user_id, date)` 단위 캐싱 — 동일 날짜 재호출 시 `daily_assignments` 행을 그대로 반환. `POST /api/today/refresh`만 추가 호출 발생, 일 3회 제한.
+
+## 1. 입력 컨텍스트 스키마
+
+서버는 다음 객체를 **JSON 직렬화** 후 system + user 메시지로 분할해 전달한다.
+
+```jsonc
+{
+  "user": {
+    "id": 42,
+    "name": "민지",
+    "registered_at": "2026-04-01"
+  },
+  "preferences": {
+    "goals": ["muscle_gain", "conditioning"],
+    "equipment": ["bodyweight", "dumbbell"],
+    "available_minutes": 20,
+    "difficulty": "intermediate",
+    "push_time": "09:00",
+    "timezone": "Asia/Seoul"
+  },
+  "today": "2026-05-03",
+  "recent_assignments": [
+    {
+      "date": "2026-05-02",
+      "program_id": 567,
+      "program_title": "Cindy Variation",
+      "completed": true,
+      "completion_time": 1062,
+      "skipped": false,
+      "user_feedback": null
+    },
+    {
+      "date": "2026-05-01",
+      "program_id": 432,
+      "program_title": "Tabata Squats",
+      "completed": true,
+      "completion_time": 480,
+      "skipped": false,
+      "user_feedback": "easy"
+    }
+  ],
+  "recent_records": [
+    {
+      "date": "2026-05-02",
+      "program_id": 567,
+      "completion_time": 1062,
+      "notes": "마지막 라운드 풀업이 힘들었음"
+    }
+  ],
+  "available_programs": [
+    {
+      "id": 100,
+      "title": "Push Day Custom",
+      "workout_type": "round_based",
+      "difficulty": "intermediate",
+      "expected_minutes": 18,
+      "exercises": [
+        { "name": "푸시업", "target_value": "15회" },
+        { "name": "덤벨 프레스", "target_value": "10회" }
+      ],
+      "source": "user_library"
+    }
+    // ... 최대 30개
+  ]
+}
+```
+
+### 1.1 데이터 수집 쿼리 가이드
+
+- `preferences`: `user_preferences` 테이블에서 `user_id`로 조회. 미입력 시 기본값(목표=`general_fitness`, 기구=`bodyweight`, 시간=20, 난이도=`intermediate`).
+- `recent_assignments`: `daily_assignments WHERE user_id = ? AND date >= today - 7`. 직전 7일 anti-repeat 시그널.
+- `recent_records`: `workout_records WHERE user_id = ? AND completed_at >= today - 30`. 페이스/볼륨 시그널.
+- `available_programs`:
+  - 사용자 본인이 만든 `programs` (creator_id == user_id) 모두.
+  - 공개 풀에서 무작위 N개 (예: 20개) 추가 — `programs` 테이블 활용. 마켓플레이스 라우트는 deprecate되었지만 데이터는 후보로 사용 가능.
+  - 직전 7일 추천된 program_id는 `available_programs`에서 제외.
+  - `expected_minutes`는 `WorkoutPatterns.time_cap_per_round * total_rounds` 또는 `target_value` 파싱으로 추정.
+
+## 2. 시스템 프롬프트 초안 (`SYSTEM_PROMPT_RECOMMEND`)
+
+```
+당신은 사용자에게 매일 1개의 운동(WOD)을 추천하는 개인 PT 코치입니다.
+사용자 데이터(선호·과거 기록·직전 7일 추천 이력)와 후보 WOD 목록을 보고,
+오늘 가장 적합한 WOD 하나를 골라 program_id로 지정하세요.
+
+## 선택 원칙
+1. 사용자의 `preferences.goals`와 `preferences.equipment`에 부합하는 WOD를 우선합니다.
+   - equipment에 없는 기구가 메인이면 후보에서 제외.
+2. `preferences.available_minutes`의 ±20% 범위에 들어오는 WOD를 우선합니다.
+3. `preferences.difficulty`와 일치 또는 한 단계 차이만 허용.
+4. 직전 7일에 이미 추천된 program_id는 절대 다시 고르지 마세요.
+5. `recent_records`로 보아 평균 완료 시간이 목표 시간보다 짧다면 난이도를 한 단계 올리고,
+   길거나 스킵이 많다면 한 단계 내리세요.
+6. `user_feedback == "easy"`가 직전에 있었다면 강도를 올리고,
+   `"hard"` 또는 `"skip"`이면 회복 강도(낮은 볼륨)로 추천하세요.
+7. 후보가 부족하거나 모두 부적합하면 `program_id: null`로 반환하고
+   `rationale`에 그 이유를 한국어 1문장으로 적으세요.
+
+## 출력 형식 (반드시 JSON 한 줄만)
+{
+  "program_id": <number | null>,
+  "rationale": "<한국어 1~2문장>",
+  "intensity_hint": "<easy|moderate|hard>",
+  "duration_estimate_minutes": <number>
+}
+
+규칙:
+- 반드시 JSON 객체 하나만 출력. 마크다운/설명/코드 블록 금지.
+- rationale은 사용자가 운동 직전에 읽을 톤(친근하고 실용적). 수치를 인용하면 좋음.
+- intensity_hint는 사용자에게 표시되지 않더라도 다음 추천 보정용으로 기록.
+```
+
+## 3. 사용자 메시지 페이로드
+
+```
+오늘 날짜: {today}
+사용자: {user.name} (id={user.id})
+
+선호:
+- 목표: {preferences.goals}
+- 기구: {preferences.equipment}
+- 가용 시간: {preferences.available_minutes}분
+- 난이도: {preferences.difficulty}
+
+직전 7일 추천 이력:
+{recent_assignments를 한 줄씩 요약}
+
+최근 30일 운동 기록 요약:
+- 완료: {count}회, 평균 {avg_min}분
+- 스킵: {skip_count}회
+
+후보 WOD (program_id, 제목, 난이도, 예상시간, 기구):
+{available_programs를 표 형식으로}
+
+위 정보를 토대로 오늘의 추천 WOD 하나를 JSON으로 출력하세요.
+```
+
+## 4. 응답 검증 (서버 측)
+
+```python
+def parse_grok_response(text: str, candidate_ids: set[int]) -> dict:
+    data = json.loads(text)
+    pid = data.get("program_id")
+    if pid is not None and pid not in candidate_ids:
+        # 헛소리 program_id → None 으로 강등
+        pid = None
+    return {
+        "program_id": pid,
+        "rationale": (data.get("rationale") or "").strip()[:300],
+        "intensity_hint": data.get("intensity_hint") or "moderate",
+        "duration_estimate_minutes": int(data.get("duration_estimate_minutes") or 0),
+    }
+```
+
+JSON 파싱 실패 시: 후보 중 무작위 1개로 폴백, `rationale`은 기본 문구.
+
+## 5. 캐싱 + 재호출 흐름
+
+```mermaid
+flowchart LR
+    A[GET /api/today] --> B{daily_assignments에<br/>오늘 행 있음?}
+    B -->|Yes| C[기존 행 반환]
+    B -->|No| D[recommendations.generate]
+    D --> E[Grok 호출]
+    E --> F[daily_assignments INSERT]
+    F --> C
+
+    R[POST /api/today/refresh] --> G{refresh_count < 3?}
+    G -->|No| H[422 Too Many Requests]
+    G -->|Yes| I[direct ←  Grok 재호출]
+    I --> J[daily_assignments UPDATE<br/>refresh_count++]
+    J --> C
+```
+
+## 6. 피드백 시그널 (Phase 4)
+
+`daily_assignments`에 `feedback_json` 컬럼 추가:
+
+```jsonc
+{
+  "intensity_hint": "moderate",
+  "user_feedback": "easy" | "hard" | "skip" | null,
+  "refresh_count": 0,
+  "client_meta": { "device": "ios", "app_version": "1.0.0" }
+}
+```
+
+UI에서 [건너뛰기]는 `user_feedback="skip"`, [다른 추천] 클릭은 직전 추천을 `"refused"`로 마킹 후 새로 호출.
+
+## 7. 보안·비용 관리
+
+- `XAI_API_KEY` 미설정 시 라우트는 503을 반환하고 워커는 발송을 건너뜀(크래시 금지).
+- 일일 푸시 워커는 사용자별 1회 호출 + refresh는 최대 3회 → 1인당 최대 4회/일.
+- 응답 사이즈는 `XAI_MAX_TOKENS=300`로 제한.
+- 토큰 정확도 향상을 위해 후보 WOD 목록은 30개 이하로 잘라 전달.

--- a/docs/DATA_MIGRATION_PLAN.md
+++ b/docs/DATA_MIGRATION_PLAN.md
@@ -1,0 +1,157 @@
+# 데이터 마이그레이션 계획 — 마켓플레이스 → 개인 PT
+
+## 0. 원칙
+
+- **데이터는 보존, API와 UI만 차단.** 기존 사용자 활동(`Registrations`, `ProgramParticipants`, `WorkoutRecords`)은 한 줄도 삭제하지 않는다.
+- **기존 모델은 nullable 컬럼만 유지하고 신규 로직에서 미사용.** 컬럼 DROP은 1단계 안정화 이후 별도 마이그레이션으로 처리.
+- **신규 모델은 추가만(ADD) — 기존 테이블 변경 최소화.** Alembic을 사용하지 않으므로 [backend/migrations/](../backend/migrations/) 폴더의 기존 패턴(SQL+Python 스크립트)을 그대로 따른다.
+
+## 1. 신규 테이블 DDL
+
+### 1.1 `user_preferences`
+
+```sql
+CREATE TABLE IF NOT EXISTS user_preferences (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    goals TEXT,                       -- JSON array, e.g. ["muscle_gain","conditioning"]
+    equipment TEXT,                   -- JSON array, e.g. ["bodyweight","dumbbell"]
+    available_minutes INTEGER DEFAULT 20,
+    difficulty VARCHAR(20) DEFAULT 'intermediate',
+    push_time VARCHAR(5) DEFAULT '09:00',  -- 'HH:MM' 24h
+    timezone VARCHAR(64) DEFAULT 'Asia/Seoul',
+    push_enabled BOOLEAN DEFAULT TRUE,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT user_preferences_user_uniq UNIQUE (user_id)
+);
+CREATE INDEX IF NOT EXISTS idx_user_preferences_user_id ON user_preferences(user_id);
+```
+
+### 1.2 `daily_assignments`
+
+```sql
+CREATE TABLE IF NOT EXISTS daily_assignments (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    assignment_date DATE NOT NULL,
+    program_id INTEGER REFERENCES programs(id) ON DELETE SET NULL,
+    source VARCHAR(20) DEFAULT 'ai_grok', -- 'ai_grok' | 'self_pick' | 'fallback'
+    ai_rationale TEXT,
+    intensity_hint VARCHAR(20),
+    duration_estimate_minutes INTEGER,
+    refresh_count INTEGER DEFAULT 0,
+    completed_at TIMESTAMP,
+    skipped_at TIMESTAMP,
+    feedback_json TEXT,            -- JSON {user_feedback, ...}
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT daily_assignments_user_date_uniq UNIQUE (user_id, assignment_date)
+);
+CREATE INDEX IF NOT EXISTS idx_daily_assignments_user_date ON daily_assignments(user_id, assignment_date);
+```
+
+### 1.3 `push_tokens`
+
+```sql
+CREATE TABLE IF NOT EXISTS push_tokens (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    platform VARCHAR(10) NOT NULL,  -- 'ios' | 'android' | 'web'
+    token VARCHAR(512) NOT NULL,
+    app_version VARCHAR(32),
+    last_seen_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    is_active BOOLEAN DEFAULT TRUE,
+    CONSTRAINT push_tokens_user_token_uniq UNIQUE (user_id, token)
+);
+CREATE INDEX IF NOT EXISTS idx_push_tokens_user ON push_tokens(user_id);
+CREATE INDEX IF NOT EXISTS idx_push_tokens_active ON push_tokens(is_active) WHERE is_active = TRUE;
+```
+
+## 2. 기존 테이블에 대한 처리
+
+| 테이블 | 처리 |
+|---|---|
+| `users` | 변경 없음. 사용자 식별자 유지. |
+| `programs` | 변경 없음. `expires_at`, `is_open`은 nullable 유지(데이터 보존). 신규 로직은 사용 안 함. |
+| `program_exercises`, `workout_patterns`, `exercise_sets`, `exercises`, `exercise_categories` | 변경 없음. AI 추천 후보 풀로 활용. |
+| `personal_goals` | 변경 없음. History 화면에서 계속 표시. |
+| `workout_records` | 변경 없음. `daily_assignments.completed_at`이 채워질 때 동시에 `workout_records`에 INSERT (기존 [POST /api/programs/{id}/records](../backend/routes/workout_records.py) 흐름 그대로 사용). |
+| `registrations` | **읽기 전용 보존**. 신규 로직 미사용. 마켓플레이스 라우트가 410을 반환하므로 신규 INSERT는 더 이상 발생하지 않음. |
+| `program_participants` | **읽기 전용 보존**. 동일. |
+| `notifications` | 변경 없음. 단, `type` 값에 `'daily_recommendation'`, `'wod_completed_streak'` 같은 신규 종류 추가 (스키마 변경 아님). |
+| `email_verifications`, `password_resets` | 변경 없음. |
+
+## 3. 마이그레이션 스크립트 위치
+
+- [backend/migrations/add_pt_tables.py](../backend/migrations/add_pt_tables.py) — 신규 3개 테이블을 IDEMPOTENT하게 생성. (Phase 1에서 작성)
+- [backend/migrations/add_pt_tables.sql](../backend/migrations/add_pt_tables.sql) — 동일 SQL 버전. Railway 콘솔에서 직접 실행 가능.
+- 기존 패턴 참조: [backend/migrations/add_email_verification_table.py](../backend/migrations/add_email_verification_table.py).
+
+> 주의: 본 프로젝트는 Alembic을 도입하지 않았다. 플랜 본문의 "Alembic migration in `backend/migrations/versions/`" 표현은 Alembic이 도입된 다른 프로젝트의 관행을 인용한 것일 뿐, **실제로는 단순 Python+SQL 스크립트로 작성**한다.
+
+## 4. 백엔드 라우트 deprecation 매트릭스
+
+| 라우트 | 현 상태 | 새 처리 |
+|---|---|---|
+| `POST /api/programs/{id}/open` | 활성 | 410 Gone (`MARKETPLACE_ENABLED=False` 가드) |
+| `POST /api/programs/{id}/join` | 활성 | 410 Gone |
+| `DELETE /api/programs/{id}/leave` | 활성 | 410 Gone |
+| `GET /api/programs/{id}/results` | 활성 | 410 Gone |
+| `GET /api/programs/{id}/participants` | 활성 | 410 Gone |
+| `PUT /api/programs/{id}/participants/{uid}/approve` | 활성 | 410 Gone |
+| `GET /api/programs` | 활성 (공개 목록) | 그대로 유지 — 라이브러리 후보 풀로 사용 |
+| `GET /api/programs/{id}` | 활성 (상세) | 그대로 유지 |
+| `POST /api/programs` | 활성 (생성) | 그대로 유지 — Library 화면에서 호출 |
+| `PUT /api/programs/{id}` | 활성 (수정) | 그대로 유지 |
+| `DELETE /api/programs/{id}` | 활성 (삭제) | 그대로 유지 |
+| `GET /api/user/programs` | 활성 (내 WOD) | 그대로 유지 |
+| `GET /api/user/wod-status` | 활성 | 그대로 유지(또는 응답 단순화) |
+| `POST /api/programs/{id}/records` 등 | 활성 (기록) | 그대로 유지 |
+
+`programs.py` 상단에 다음 가드 추가:
+
+```python
+import os
+MARKETPLACE_ENABLED = os.environ.get('MARKETPLACE_ENABLED', 'false').lower() == 'true'
+
+def _gone_if_marketplace_disabled():
+    if not MARKETPLACE_ENABLED:
+        return jsonify({
+            'error': 'gone',
+            'message': '공개 마켓플레이스 기능은 PT 모델로 전환되어 종료되었습니다.'
+        }), 410
+    return None
+```
+
+각 deprecate 대상 라우트 함수의 첫 줄에 다음을 삽입:
+
+```python
+gone = _gone_if_marketplace_disabled()
+if gone is not None:
+    return gone
+```
+
+기존 코드 본문은 그대로 두어 환경변수만 바꾸면 부활 가능 (긴급 롤백 대비).
+
+## 5. 데이터 백필(backfill) 정책
+
+- **불필요**. 신규 테이블은 처음에 빈 상태로 시작하고, 사용자 첫 로그인/푸시 권한 부여 시 자연 증가한다.
+- 단, **온보딩 안내 모달**(웹·앱 동일)을 첫 로그인 시 1회 노출해 "이전 마켓플레이스 기능은 종료되었음"과 "선호도 입력으로 이동" CTA를 제공할 것 — UI Phase 2 작업.
+
+## 6. 롤백 전략
+
+| 시나리오 | 롤백 방법 |
+|---|---|
+| 마켓플레이스를 일시 부활시키고 싶음 | `MARKETPLACE_ENABLED=true` 환경변수 → 재배포만 필요. 코드 변경 X. |
+| 신규 테이블이 문제를 일으킴 | `DROP TABLE user_preferences, daily_assignments, push_tokens;` — 기존 사용자 데이터에는 영향 없음. |
+| Grok 호출이 비용 폭주 | 라우트 단에서 `XAI_API_KEY` 비우기 → 503 + UI 에러 메시지. 대체 폴백으로 `available_programs`에서 무작위 선택. |
+| 푸시 워커가 폭주 | APScheduler 잡 중지 (`scheduler.pause()`) — `app.py`에 토글 환경변수 노출. |
+
+## 7. 운영 체크리스트(요약)
+
+- [ ] 신규 환경변수 등록: `XAI_API_KEY`(이미 사용), `APNS_KEY_P8`, `APNS_KEY_ID`, `APNS_TEAM_ID`, `APNS_BUNDLE_ID`, `FCM_SERVICE_ACCOUNT_JSON`, `MARKETPLACE_ENABLED=false`, `PT_PUSH_ENABLED=true`.
+- [ ] 마이그레이션 스크립트 실행 (`python migrations/add_pt_tables.py`).
+- [ ] `MuiProgramsPage.tsx`/`MuiSharedProgramPage.tsx` 임포트 제거 또는 `.deprecated.tsx` 리네임.
+- [ ] 첫 배포 후 24시간 모니터링: `daily_assignments` insert rate, Grok 4xx/5xx, 푸시 발송 실패율.

--- a/docs/IA_AND_WIREFRAMES.md
+++ b/docs/IA_AND_WIREFRAMES.md
@@ -1,0 +1,226 @@
+# WODYBODY 정보 구조(IA) + 텍스트 와이어프레임
+
+## 0. 화면 분류 (총 4개 메인 + 부속)
+
+```
+[ 인증 ]
+  ├─ login
+  ├─ register
+  └─ passwordReset
+
+[ 메인 (인증 후, 하단 탭) ]
+  ├─ today          ← 기본 랜딩
+  ├─ history
+  ├─ library
+  └─ preferences
+
+[ 부속 / 모달 ]
+  ├─ create         (Library에서 + 버튼 → 새 WOD 만들기)
+  ├─ timer          (Today/Library에서 시작 → MuiWorkoutTimer)
+  └─ notifications  (헤더 종 아이콘 → MuiNotificationsPage)
+```
+
+## 1. 네비게이션 모델
+
+```mermaid
+flowchart LR
+    L[Login] --> T[Today]
+    R[Register] --> T
+    PR[PasswordReset] --> L
+    T <--> H[History]
+    H <--> Lib[Library]
+    Lib <--> P[Preferences]
+    P <--> T
+    T -->|시작| TM[Timer]
+    Lib -->|＋| C[Create]
+    T -->|종 아이콘| N[Notifications]
+```
+
+상단: 로고·종 아이콘·드로어(아바타)
+하단(또는 상단 탭, MuiNavigation 재활용): Today / History / Library / Preferences
+
+## 2. 화면별 텍스트 와이어프레임
+
+### 2.1 Today (홈, 기본 랜딩)
+
+```
+┌───────────────────────────────────────────┐
+│  WODYBODY              🔔(3)         👤   │
+├───────────────────────────────────────────┤
+│  Today · History · Library · Preferences  │  ← 탭
+├───────────────────────────────────────────┤
+│                                            │
+│  2026년 5월 3일 (일)                        │
+│  좋은 아침이에요, 민지님!                   │
+│                                            │
+│  ┌─────────────────────────────────────┐  │
+│  │  오늘의 WOD                          │  │
+│  │  ────────────────────────            │  │
+│  │  Cindy Variation                     │  │
+│  │  20분 AMRAP · 중급                   │  │
+│  │                                      │  │
+│  │  • 풀업 5회                          │  │
+│  │  • 푸시업 10회                       │  │
+│  │  • 에어 스쿼트 15회                  │  │
+│  │                                      │  │
+│  │  💡 코치 코멘트:                      │  │
+│  │  "지난 주 3회 운동 완료, 평균 18분.   │  │
+│  │   오늘은 회복 강도로 라운드 수에      │  │
+│  │   집중하세요."                        │  │
+│  └─────────────────────────────────────┘  │
+│                                            │
+│  [   ▶ 시작하기   ]   [ 다른 추천(2/3) ]   │
+│  [ 건너뛰기 ]                              │
+│                                            │
+│  최근 7일                                   │
+│  ✅ 5/2  ✅ 5/1  ⏭ 4/30  ✅ 4/29 ...      │
+└───────────────────────────────────────────┘
+```
+
+상태별 변화:
+- **추천 미생성**: "추천 생성 중…" 스피너 + Grok 호출 후 캐시.
+- **이미 완료**: 카드 상단에 ✅, [기록 보기] 버튼.
+- **건너뜀**: 회색 톤 + [그래도 시작하기] 보조 버튼.
+- **추천 한도 초과(refresh ≥ 3)**: [다른 추천] 비활성 + "내일 다시 시도하세요" 툴팁.
+- **선호 미입력**: 추천 카드 위치에 [선호 입력하러 가기] CTA만 표시.
+
+API:
+- `GET /api/today` → `{ assignment, program, ai_rationale, refresh_count }` 또는 신규 생성.
+- `POST /api/today/refresh` → 422 (한도 초과) 또는 새 assignment.
+- `POST /api/today/complete` `{ completion_time, notes }` → 기록 저장.
+- `POST /api/today/skip` → 스킵 마킹.
+
+### 2.2 History
+
+```
+┌───────────────────────────────────────────┐
+│  History                              ⏷ │
+├───────────────────────────────────────────┤
+│  ▣ 통계 카드                              │
+│   - 이번 달: 15회 완료 / 총 4시간 22분      │
+│   - 평균 완료 시간: 17분 33초              │
+│   - 연속 운동: 4일                          │
+│                                            │
+│  📊 최근 30일 그래프 (완료/스킵 막대)         │
+│                                            │
+│  📜 기록 목록                                │
+│  5/2  Cindy Variation     17:42  ★★★★    │
+│  5/1  Tabata Squats        8:00  ★★★★★   │
+│  4/30 (스킵)                                │
+│  ...                                        │
+└───────────────────────────────────────────┘
+```
+
+재사용: 기존 [MuiPersonalRecordsPage.tsx](../frontend/src/components/MuiPersonalRecordsPage.tsx)와 [MuiPersonalStatsComponent.tsx](../frontend/src/components/MuiPersonalStatsComponent.tsx)를 그대로 사용. `daily_assignments`의 skip 데이터를 추가로 표시할 수 있도록 `workout_records` 조회 응답에 합치는 백엔드 작업이 Phase 4에 포함될 수 있음(선택적).
+
+### 2.3 Library (내 WOD)
+
+```
+┌───────────────────────────────────────────┐
+│  Library                          [ ＋ ]   │
+├───────────────────────────────────────────┤
+│  내가 만든 WOD                              │
+│                                            │
+│  ┌───────────────────────────────┐         │
+│  │ Push Day Custom               │   ▶ 시작│
+│  │ 4 라운드 · 상급                │   ✏ 편집│
+│  └───────────────────────────────┘         │
+│                                            │
+│  ┌───────────────────────────────┐         │
+│  │ Quick 10                      │   ▶ 시작│
+│  │ 10분 AMRAP · 초급             │         │
+│  └───────────────────────────────┘         │
+│                                            │
+│  추천 풀(읽기전용)                           │
+│  Grok이 제안할 수 있는 후보 30개             │
+└───────────────────────────────────────────┘
+```
+
+[+] 버튼은 기존 [MuiStepBasedCreateProgramPage.tsx](../frontend/src/components/MuiStepBasedCreateProgramPage.tsx) 재사용 → page='create'.
+
+### 2.4 Preferences
+
+```
+┌───────────────────────────────────────────┐
+│  Preferences                              │
+├───────────────────────────────────────────┤
+│  목표                                       │
+│  [ ] 체중 감량  [v] 근육 증가  [v] 컨디셔닝 │
+│                                            │
+│  사용 가능한 기구 (멀티 선택)                  │
+│  [v] 맨몸  [v] 덤벨  [ ] 케틀벨  [ ] 바벨   │
+│  [ ] 풀업바  [ ] 로잉머신                    │
+│                                            │
+│  하루 가용 시간                              │
+│  ◯ 10분  ● 20분  ◯ 30분  ◯ 45분+           │
+│                                            │
+│  난이도 선호                                  │
+│  ◯ 초급  ● 중급  ◯ 상급                     │
+│                                            │
+│  푸시 시각                                    │
+│  [ 09:00 ▼ ]    Asia/Seoul                  │
+│  [v] 매일 알림 받기                           │
+│                                            │
+│  [        저장        ]                     │
+└───────────────────────────────────────────┘
+```
+
+API:
+- `GET /api/me/preferences` → 현재 값 (없으면 빈 객체).
+- `PUT /api/me/preferences` → 저장.
+- 저장 시 푸시 토큰 등록 트리거: `POST /api/me/push-tokens` (앱 모드만).
+
+## 3. 푸시 알림 페이로드 모델
+
+```json
+{
+  "aps": {
+    "alert": {
+      "title": "오늘의 WOD가 도착했어요",
+      "body": "Cindy Variation · 20분 AMRAP"
+    },
+    "sound": "default",
+    "badge": 1
+  },
+  "wodybody": {
+    "type": "daily_recommendation",
+    "assignment_id": 1234,
+    "program_id": 567,
+    "deeplink": "wodybody://today"
+  }
+}
+```
+
+FCM v1: 위와 동일 의미를 `notification` + `data`로 매핑.
+
+## 4. 모바일 셸 특화 UI 고려 사항
+
+- **SafeArea**: `frontend/src/index.css`에 `env(safe-area-inset-*)` 적용. iPhone 노치/홈인디케이터 보호.
+- **상태바**: `@capacitor/status-bar`로 라이트/다크 토글에 따라 동기화.
+- **스플래시**: `@capacitor/splash-screen` — `mobile/resources/splash.png` 사용.
+- **딥링크**: `wodybody://today`, `wodybody://history`, `wodybody://preferences`.
+- **키보드**: `@capacitor/keyboard`로 Login/Register 입력 시 vh 조정.
+- **자동 인증 유지**: JWT를 `@capacitor/preferences`에 저장 (네이티브) / `localStorage` (웹).
+
+## 5. 페이지 enum 정의 (frontend/src/types/index.ts)
+
+```ts
+export type Page =
+  | 'login' | 'register' | 'passwordReset'
+  | 'today'
+  | 'history'
+  | 'library'
+  | 'preferences'
+  | 'create';
+```
+
+## 6. App.tsx 라우팅 변경 요약
+
+```ts
+useEffect(() => {
+  if (user) setPage('today');   // ← 'programs' 에서 변경
+  else setPage('login');
+}, [user]);
+```
+
+마켓플레이스 page 분기(`'programs'`, `'my'`, `'records'`)는 모두 제거 또는 deprecate 처리. `records` → `history`, `my` → `library`.

--- a/docs/PT_SERVICE_REDESIGN.md
+++ b/docs/PT_SERVICE_REDESIGN.md
@@ -1,0 +1,134 @@
+# WODYBODY 서비스 재정의 — 공개 마켓플레이스에서 개인 PT로
+
+## 0. TL;DR
+
+WODYBODY를 **"공개 WOD 마켓플레이스"**에서 **"AI(Grok)가 매일 오늘의 운동을 추천·푸시하는 개인 PT"** 로 재정의한다. 기존 CRA + MUI 웹 프론트엔드는 그대로 유지하되, Capacitor 7.x로 래핑해 iOS/Android 모바일 앱으로 출시한다. Burnfat 서비스는 별도 도메인/스택이며 본 재설계의 **범위 밖**이다.
+
+## 1. 왜 바꾸는가
+
+기존 마켓플레이스 모델의 문제:
+
+- **공급 측 빈약**: 신규 사용자가 들어와도 공개 WOD가 충분하지 않으면 첫 인상이 빈약. "황금시간(`expires_at`)" 컨셉도 콜드스타트 문제를 가속.
+- **소비 측 결정피로**: 사용자에게 "오늘 어떤 WOD를 할까?"를 매번 결정시키는 것은 PT라기보다 콘텐츠 큐레이션 부담.
+- **참여 신청·승인 흐름 과잉**: `Registrations`, `ProgramParticipants`, `pending/approved/rejected/left` 등 SaaS급 복잡도가 1인용 운동 도구로는 과해.
+- **모바일 핏 부재**: 수익성 있는 운동 앱 시장은 푸시 + 일일 루틴이 핵심인데 현재 IA는 그 흐름이 빠짐.
+
+새 모델의 이점:
+
+- **결정 부담 0**: 매일 아침/저녁 정해진 시간에 푸시로 "오늘의 WOD"가 도착. 사용자는 [시작]만 누르면 된다.
+- **개인화**: 선호도(목표·기구·가용시간·난이도) + 과거 30일 기록 + 직전 7일 추천 이력을 모두 Grok 프롬프트에 전달해 매번 다른 추천을 생성.
+- **모바일 1순위**: Capacitor 셸 + `@capacitor/push-notifications`로 iOS(APNs)·Android(FCM) 정식 푸시 지원.
+- **재사용 극대화**: 기존 [MuiStepBasedCreateProgramPage](../frontend/src/components/MuiStepBasedCreateProgramPage.tsx), [MuiWODBuilder](../frontend/src/components/MuiWODBuilder.tsx), [MuiWorkoutTimer](../frontend/src/components/MuiWorkoutTimer.tsx), [MuiPersonalRecordsPage](../frontend/src/components/MuiPersonalRecordsPage.tsx)는 그대로 사용. 신규 화면은 Today / Preferences 두 개뿐.
+
+## 2. 핵심 사용자 시나리오
+
+```mermaid
+flowchart LR
+    A[가입/온보딩] --> B[선호 입력]
+    B --> C[푸시 권한 요청]
+    C --> D[(다음 날 09:00)]
+    D --> E[푸시 도착<br/>"오늘의 WOD"]
+    E --> F{사용자 선택}
+    F -->|시작| G[타이머]
+    F -->|다른 추천| H[Grok 재호출<br/>일 3회 한도]
+    F -->|건너뛰기| I[skipped 기록]
+    G --> J[기록 저장]
+    J --> K[History·통계 갱신]
+    H --> E
+    I --> D
+```
+
+신규 사용자 첫 7일:
+
+1. D+0: 가입 → 선호 입력 → 푸시 권한 → 즉시 첫 추천 표시.
+2. D+1~6: 정해진 push_time에 알림. 완료/스킵 데이터 누적.
+3. D+7: 추천이 사용자 패턴(완료 시간·스킵률)에 적응하기 시작 — 난이도·볼륨 자동 조정.
+
+## 3. 유지·제거·신규 결정표
+
+| 분류 | 항목 | 결정 |
+|---|---|---|
+| 유지 | 회원가입·로그인·이메일 인증·비밀번호 재설정 | 그대로 |
+| 유지 | JWT Bearer 인증 ([backend/app.py:42-127](../backend/app.py)) | 그대로 (모바일 친화적) |
+| 유지 | WOD 직접 만들기 ([MuiStepBasedCreateProgramPage.tsx](../frontend/src/components/MuiStepBasedCreateProgramPage.tsx)) | "라이브러리" 탭에서 사용 |
+| 유지 | 운동 타이머 ([MuiWorkoutTimer.tsx](../frontend/src/components/MuiWorkoutTimer.tsx)) | Today에서 호출 |
+| 유지 | 개인 기록·통계 ([MuiPersonalRecordsPage.tsx](../frontend/src/components/MuiPersonalRecordsPage.tsx)) | History 탭으로 이름만 변경 |
+| 유지 | 알림 페이지 ([MuiNotificationsPage.tsx](../frontend/src/components/MuiNotificationsPage.tsx)) | 컨텐츠를 "추천 도착" 위주로 |
+| 유지 | `programs` 테이블 + `workout_records` + `personal_goals` | 데이터·모델 보존 |
+| 제거(deprecate API) | `/api/programs/{id}/open` | 410 Gone |
+| 제거(deprecate API) | `/api/programs/{id}/register` `/unregister` | 410 Gone (코드상은 라우트 미존재 — `/join` `/leave`만 존재) |
+| 제거(deprecate API) | `/api/programs/{id}/results` | 410 Gone |
+| 제거(deprecate API) | `/api/programs/{id}/join` `/leave` | 410 Gone |
+| 제거(UI) | [MuiProgramsPage.tsx](../frontend/src/components/MuiProgramsPage.tsx) | 코드 삭제 또는 `.deprecated.tsx` 리네임 |
+| 제거(UI) | [MuiSharedProgramPage.tsx](../frontend/src/components/MuiSharedProgramPage.tsx) | 코드 삭제 또는 `.deprecated.tsx` 리네임 |
+| 보존(데이터) | `Registrations`, `ProgramParticipants` 테이블 | 마이그레이션 없음. 새 로직만 사용 안 함 |
+| 보존(컬럼) | `programs.expires_at`, `programs.is_open` | nullable 유지, 신규 로직에서 미사용 |
+| 신규(모델) | `user_preferences` | 사용자별 PT 설정 |
+| 신규(모델) | `daily_assignments` | (user_id, date) 기준 오늘의 WOD 캐시 |
+| 신규(모델) | `push_tokens` | iOS/Android 디바이스 토큰 |
+| 신규(라우트) | `/api/me/preferences` `GET PUT` | |
+| 신규(라우트) | `/api/today` `GET` `/api/today/refresh` `POST` `/api/today/complete` `POST` `/api/today/skip` `POST` | |
+| 신규(라우트) | `/api/recommendations/generate` (내부용) | |
+| 신규(라우트) | `/api/me/push-tokens` `POST DELETE` | |
+| 신규(워커) | `backend/utils/scheduler.py` (APScheduler 인-프로세스) | 일일 푸시 발송 |
+| 신규(셸) | `mobile/` Capacitor 7.x | |
+
+## 4. 주요 컴포넌트와 경로 매핑
+
+```mermaid
+flowchart TB
+    subgraph Mobile/Web["Capacitor App + Web (frontend/)"]
+        T[MuiTodayPage]
+        P[MuiPreferencesPage]
+        H[MuiPersonalRecordsPage<br/>= History]
+        L[Library = my WODs]
+        TM[MuiWorkoutTimer]
+        N[MuiNotificationsPage]
+    end
+
+    subgraph Backend["backend/"]
+        TR[/api/today]
+        PR[/api/me/preferences]
+        PUSH[/api/me/push-tokens]
+        REC[/api/recommendations/generate]
+        SCHED[utils/scheduler.py]
+    end
+
+    subgraph External
+        GROK[xAI Grok API]
+        APNS[APNs HTTP/2]
+        FCM[FCM HTTP v1]
+    end
+
+    T <--> TR
+    P <--> PR
+    T --> TM
+    SCHED --> REC
+    REC --> GROK
+    SCHED --> APNS
+    SCHED --> FCM
+    Mobile/Web -- 디바이스 토큰 --> PUSH
+```
+
+## 5. 측정 가능한 성공 지표
+
+- 신규가입 → D+1 푸시 수신율 ≥ 80%
+- 푸시 → "오늘의 WOD" 화면 진입율 ≥ 40%
+- "다른 추천 받기" 평균 호출 < 0.5회/일·사용자 (Grok 비용 통제)
+- D+7 잔존율 ≥ 30% (개인 PT 컨셉 검증)
+- 일 평균 완료된 WOD 수 ≥ 0.6/사용자
+
+## 6. 비-목표 (이번 재설계에서 안 하는 것)
+
+- Burnfat 통합·코드 공유 — Burnfat은 별도 서비스로 유지.
+- 영양·식단·체지방 트래킹 — Burnfat 영역.
+- 그룹 챌린지·실시간 랭킹 — 마켓플레이스 잔재이므로 deprecate.
+- 결제·구독 — 1차 출시 후 별도 단계.
+
+## 7. 참고 파일
+
+- 기존 인증 시스템: [backend/app.py](../backend/app.py)
+- Grok 호출 패턴 레퍼런스: [backend/routes/burnfat_ai.py](../backend/routes/burnfat_ai.py)
+- 기존 프론트 라우팅: [frontend/src/App.tsx](../frontend/src/App.tsx)
+- 기존 API 클라이언트: [frontend/src/utils/api.ts](../frontend/src/utils/api.ts)
+- 기존 타입: [frontend/src/types/index.ts](../frontend/src/types/index.ts)

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -1,0 +1,230 @@
+# WODYBODY 출시 체크리스트 — iOS App Store + Google Play
+
+> 본 문서는 WODYBODY 모바일 앱(`mobile/`)을 TestFlight/Internal Testing 단계에서 프로덕션까지 진행하기 위한 단계별 체크리스트다. Burnfat은 별도 서비스이며 본 문서 대상에 포함되지 않는다.
+
+## 0. 사전 결정 사항
+
+- **Bundle ID / Package**: `com.wodybody.app`
+- **앱 이름**: WODYBODY
+- **카테고리**: 건강 및 피트니스 (Health & Fitness)
+- **연령 등급**: 4+ (운동 정보, 건강 관련 일반 콘텐츠)
+- **지원 언어**: 한국어(주), 영어(보조)
+- **배포 채널**: App Store(iOS), Google Play(Android), 웹은 기존 Vercel 유지
+
+## 1. Apple Developer Program (iOS)
+
+- [ ] [Apple Developer Program 가입](https://developer.apple.com/programs/) — 연 $99. 개인 또는 법인 계정. 법인일 경우 D-U-N-S 번호 필요.
+- [ ] [App Store Connect](https://appstoreconnect.apple.com)에서 새 앱 등록
+  - Bundle ID: `com.wodybody.app` (Identifiers에서 먼저 등록)
+  - SKU: `WODYBODY-001`
+  - 기본 언어: Korean
+- [ ] **APNs Authentication Key (P8)** 생성
+  - Certificates, Identifiers & Profiles → Keys → `+` → "Apple Push Notifications service (APNs)"
+  - 다운로드한 `.p8` 파일은 **단 1회만** 다운로드 가능 — 안전 보관
+  - 백엔드 환경변수에 등록할 값:
+    - `APNS_KEY_P8` = .p8 파일 본문(BEGIN PRIVATE KEY ~ END PRIVATE KEY) 또는 base64
+    - `APNS_KEY_ID` = 생성된 Key ID (10자)
+    - `APNS_TEAM_ID` = Membership Details의 Team ID (10자)
+    - `APNS_BUNDLE_ID` = `com.wodybody.app`
+    - `APNS_USE_SANDBOX` = `true` (개발/TestFlight) 또는 `false` (프로덕션)
+- [ ] **App ID에 Push Notifications capability 활성화**
+  - Identifiers → `com.wodybody.app` 편집 → "Push Notifications" 체크 → Save
+- [ ] **Provisioning Profile** 자동 생성을 Xcode에 위임 (Signing & Capabilities → Automatically manage signing)
+
+## 2. iOS Xcode 프로젝트 셋업
+
+```bash
+cd mobile
+# (이미 추가됨) npx cap add ios
+cd ios/App
+pod install
+open App.xcworkspace
+```
+
+- [ ] Xcode → 좌측 프로젝트 → `App` 타겟
+  - General → Identity → Bundle Identifier: `com.wodybody.app`
+  - Signing & Capabilities → "+ Capability" → **Push Notifications**, **Background Modes** (Remote notifications 체크)
+  - Info.plist에 다음 키 추가:
+    - `NSCameraUsageDescription` (선택, QR/사진 사용 시)
+    - `NSUserTrackingUsageDescription` (광고 식별자 사용 시 — 1차 출시는 미사용)
+- [ ] 앱 아이콘 / 스플래시: `mobile/resources/icon.png`, `splash.png`로부터
+  ```bash
+  cd mobile
+  npm install -D @capacitor/assets
+  npx capacitor-assets generate --iconBackgroundColor '#1976d2' --splashBackgroundColor '#1976d2'
+  npx cap sync ios
+  ```
+- [ ] **Build & Archive**: Xcode → Product → Archive → Distribute → App Store Connect → Upload
+- [ ] **TestFlight 내부 테스터** 등록(Apple ID 이메일) → 메일 수신 후 TestFlight 앱에서 설치 테스트.
+
+## 3. Google Play Console (Android)
+
+- [ ] [Google Play Console 가입](https://play.google.com/console) — 1회 $25.
+- [ ] 새 앱 만들기 → 앱 이름 `WODYBODY`, 기본 언어 한국어, 무료 앱.
+- [ ] 패키지명: `com.wodybody.app` (Capacitor가 이미 설정).
+
+## 4. Firebase Cloud Messaging (FCM, Android)
+
+- [ ] [Firebase Console](https://console.firebase.google.com)에서 프로젝트 생성 (예: `wodybody-prod`)
+- [ ] Android 앱 추가 — package name `com.wodybody.app`
+- [ ] `google-services.json` 다운로드 → `mobile/android/app/google-services.json`에 배치
+- [ ] `mobile/android/build.gradle` (project-level)에 classpath 추가:
+  ```gradle
+  classpath 'com.google.gms:google-services:4.4.2'
+  ```
+- [ ] `mobile/android/app/build.gradle` 하단:
+  ```gradle
+  apply plugin: 'com.google.gms.google-services'
+  ```
+- [ ] **Service Account JSON** 발급 (Firebase Console → 프로젝트 설정 → 서비스 계정 → 새 비공개 키 생성)
+  - 백엔드 환경변수: `FCM_SERVICE_ACCOUNT_JSON` = 다운로드한 JSON 파일 본문 (또는 base64)
+  - `FCM_PROJECT_ID` = Firebase 프로젝트 ID (예: `wodybody-prod`)
+
+## 5. Android 빌드 + 서명
+
+```bash
+cd mobile
+npm run build:web
+npx cap copy android
+npx cap open android   # Android Studio
+```
+
+- [ ] **Keystore 생성** (Android Studio → Build → Generate Signed Bundle/APK → Create new)
+  - 비밀번호·alias·.keystore 파일 안전 보관 (분실 시 앱 업데이트 불가)
+- [ ] `build.gradle (Module: app)`에 signingConfig 추가:
+  ```gradle
+  signingConfigs {
+      release {
+          storeFile file('../keystore/wodybody.keystore')
+          storePassword System.getenv('WODYBODY_KEYSTORE_PASSWORD')
+          keyAlias 'wodybody'
+          keyPassword System.getenv('WODYBODY_KEY_PASSWORD')
+      }
+  }
+  buildTypes { release { signingConfig signingConfigs.release } }
+  ```
+- [ ] **App Bundle (.aab) 생성**: Build → Generate Signed Bundle → Android App Bundle.
+- [ ] Play Console → 내부 테스트 트랙 → .aab 업로드 → 테스터(이메일 그룹) 추가.
+
+## 6. 백엔드 환경변수 (Railway / Production)
+
+| 변수 | 용도 |
+|---|---|
+| `XAI_API_KEY` | Grok 추천 호출 |
+| `XAI_MODEL` | (선택) 기본 `grok-4-1-fast-non-reasoning` |
+| `APNS_KEY_P8` | iOS 푸시 P8 키 본문 |
+| `APNS_KEY_ID` | iOS 푸시 Key ID |
+| `APNS_TEAM_ID` | Apple Team ID |
+| `APNS_BUNDLE_ID` | `com.wodybody.app` |
+| `APNS_USE_SANDBOX` | `true` 또는 `false` |
+| `FCM_SERVICE_ACCOUNT_JSON` | FCM v1 서비스 계정 JSON |
+| `FCM_PROJECT_ID` | Firebase 프로젝트 ID |
+| `MARKETPLACE_ENABLED` | `false` (PT 모델만 노출) |
+| `PT_PUSH_ENABLED` | `true` (워커 활성) |
+| `PT_PUSH_WORKER_ENABLED` | `true` |
+| `PT_DAILY_REFRESH_LIMIT` | `3` (1인당 일 새로받기 한도) |
+| `PT_CANDIDATE_POOL_LIMIT` | `30` |
+
+배포 후 1회만 실행:
+
+```bash
+cd backend
+python migrations/add_pt_tables.py
+```
+
+## 7. 스토어 메타데이터
+
+### 7.1 공통 — 스크린샷
+
+5장 권장 (모두 한국어 UI):
+
+1. Today — 오늘의 WOD + AI 코멘트
+2. Today — "다른 추천" 클릭 후 새 WOD
+3. History — 운동 기록 + 통계
+4. Library — 내가 만든 WOD 리스트 + [+] 새로 만들기
+5. Preferences — 푸시 시각·기구·난이도
+
+권장 사이즈:
+
+| 디바이스 | 사이즈 | 출처 |
+|---|---|---|
+| iPhone 6.9" (15 Pro Max) | 1290×2796 | Xcode Simulator |
+| iPhone 6.5" (Plus) | 1242×2688 | Apple 요구 |
+| iPad 13" | 2064×2752 | Apple 요구 |
+| Android Phone | 1080×1920 이상 | Play Console 권장 |
+| Android Tablet (선택) | 1920×1200 | |
+
+### 7.2 앱 설명 (한국어)
+
+> WODYBODY는 매일 아침 AI 코치(Grok)가 당신에게 딱 맞는 오늘의 운동을 추천하고 푸시로 알려주는 개인 PT 앱입니다.
+>
+> ✓ 매일 09시(또는 원하는 시간)에 푸시로 도착하는 "오늘의 WOD"
+> ✓ 목표·기구·가용 시간·난이도 기반 개인화
+> ✓ 직전 7일간 추천 안 겹침 + 운동 기록 30일 분석으로 점점 더 맞춤
+> ✓ 내장 타이머로 바로 운동 시작
+> ✓ 직접 만든 WOD를 라이브러리에 저장
+> ✓ 마음에 안 들면 [다른 추천] 한 번 더 (일 3회 한도)
+
+### 7.3 키워드 (App Store)
+
+`크로스핏, WOD, 홈트, AI, 개인PT, 운동, 피트니스, 헬스, 체력, 워크아웃`
+
+### 7.4 개인정보처리방침
+
+- 호스팅 위치(권장): `https://wodybody-web.vercel.app/privacy` 또는 별도 GitHub Pages.
+- 양식 참고: `burnfat/docs/`의 기존 양식 (Burnfat 프로젝트). 본 앱용으로 다음 항목 명시:
+  - 수집 정보: 이메일·이름(가입), 운동 기록, 푸시 토큰, 디바이스 정보(앱 버전·플랫폼)
+  - AI(Grok) 처리: 추천 생성 시 사용자 운동 기록 일부가 xAI에 전송됨
+  - 보유 기간: 회원 탈퇴 시 30일 내 파기
+  - 제3자 제공: 없음 (Grok·APNs·FCM은 처리 위탁)
+
+## 8. 출시 단계 흐름
+
+```mermaid
+flowchart LR
+    A[로컬 빌드 OK] --> B[TestFlight + Internal Testing]
+    B --> C[5~10명 베타]
+    C --> D{버그·UX 피드백}
+    D -->|이슈 있음| A
+    D -->|OK| E[App Store / Play Store 심사 제출]
+    E --> F[심사 통과]
+    F --> G[프로덕션 출시]
+    G --> H[24시간 모니터링: Grok 호출률·푸시 발송률·크래시]
+```
+
+## 9. 사용자 동작 검증 시나리오
+
+테스터에게 검증을 요청할 핵심 흐름:
+
+1. 가입 → 이메일 인증 → 로그인.
+2. 처음 로그인 시 **Today**가 기본 화면이고 추천 카드가 보이는가?
+3. **Preferences**에서 목표·기구·시간·푸시 시각 저장 → 다시 Today로 돌아오면 추천이 바뀌는가?
+4. 푸시 권한 허용 → 토큰이 백엔드에 등록되는가? (`/api/me/push-tokens GET`로 확인)
+5. **다른 추천** 3회 호출 후 4회째에 한도 초과 안내가 나오는가?
+6. **시작하기** → 타이머 → 완료 → History에 기록이 추가되는가?
+7. **건너뛰기** → 다음 날 추천이 회복 강도(`intensity_hint=easy`)로 변하는가?
+8. 백그라운드에 있는 동안 푸시 도착 → 푸시 탭 → Today 화면으로 자동 이동.
+9. 앱 종료 후 재실행 시 자동 로그인 유지 (JWT가 localStorage/Capacitor Preferences에 보관).
+
+## 10. 베타 → 프로덕션 전환 체크
+
+- [ ] APNs 환경: TestFlight = sandbox, 프로덕션 빌드 업로드 시 `APNS_USE_SANDBOX=false`로 전환.
+- [ ] FCM: 동일 프로젝트로 베타·프로덕션 공용 가능. 토큰만 디바이스가 새로 발급.
+- [ ] DB 마이그레이션: 프로덕션 DB에 `add_pt_tables.py` 실행 완료.
+- [ ] 데이터 백필: 기존 가입자에게 **첫 로그인 시 1회 안내 모달** 노출 (Phase 2 UI 후속 작업).
+- [ ] 모니터링 대시보드: Railway 로그에서 `daily_push_tick`, Grok 4xx/5xx, 푸시 실패 카운트.
+
+## 11. 비상 롤백
+
+- **마켓플레이스 부활**: `MARKETPLACE_ENABLED=true` → 재배포만으로 deprecate된 라우트가 200으로 복귀.
+- **AI 호출 중단**: `XAI_API_KEY` 비우기 → 폴백(무작위)으로 자동 전환.
+- **푸시 워커 중단**: `PT_PUSH_WORKER_ENABLED=false` 후 재배포.
+- **앱 강제 업데이트**: 클라이언트에 강제 업데이트 카드를 추가하려면 `/api/version-check` 엔드포인트 신설 필요(미구현).
+
+## 12. 다음 세션 추천 시작점
+
+1. 실제 Apple Developer 계정에서 P8 키 발급 + 환경변수 설정.
+2. Firebase 프로젝트 생성 + `google-services.json` 배치.
+3. `mobile/ios/App`에서 `pod install` (Xcode 업데이트 후) → Signing 설정.
+4. TestFlight 빌드 1회 업로드 + 본인 디바이스로 푸시 수신 테스트.
+5. 첫 로그인 안내 모달(마켓플레이스 종료 안내) 추가 — 1시간 작업.


### PR DESCRIPTION
Phase 0 산출물: 서비스 재정의(PT_SERVICE_REDESIGN), 정보구조/와이어프레임(IA_AND_WIREFRAMES), Grok 추천 프롬프트(AI_RECOMMENDATION_PROMPT), 데이터 마이그레이션(DATA_MIGRATION_PLAN), 스토어 출시 체크리스트(RELEASE_CHECKLIST). 메인 앱(WODYBODY) 변경과 독립 검토 가능합니다.

Made with [Cursor](https://cursor.com)