### PR TITLE
feat(backend): PT 엔티티·추천·푸시·마켓플레이스 410

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -438,6 +438,22 @@ app.register_blueprint(email_verification.bp)
 from routes import burnfat_ai
 app.register_blueprint(burnfat_ai.bp)
 
+# WODYBODY PT — 사용자 선호 설정
+from routes import preferences as pt_preferences
+app.register_blueprint(pt_preferences.bp)
+
+# WODYBODY PT — 오늘의 WOD
+from routes import today as pt_today
+app.register_blueprint(pt_today.bp)
+
+# WODYBODY PT — Grok 추천 엔진(내부/디버그)
+from routes import recommendations as pt_recommendations
+app.register_blueprint(pt_recommendations.bp)
+
+# WODYBODY PT — 푸시 토큰 등록
+from routes import push as pt_push
+app.register_blueprint(pt_push.bp)
+
 # WebSocket 이벤트 핸들러 등록 (app.py에 직접 정의)
 @socketio.on('connect')
 def handle_connect():
@@ -478,6 +494,16 @@ def handle_leave_user_room(data):
         print(f'👤 사용자 {user_id}가 방에서 나갔습니다.')
 
 print("✅ All blueprints and WebSocket handlers registered successfully!")
+
+
+# ==================================================================
+# WODYBODY PT — 일일 푸시 워커 (APScheduler 인-프로세스)
+# ==================================================================
+try:
+    from utils.scheduler import start_scheduler
+    start_scheduler(app)
+except Exception as _scheduler_exc:  # pragma: no cover
+    app.logger.warning('PT push scheduler start skipped: %s', _scheduler_exc)
 
 
 # ==================================================================

--- a/backend/migrations/add_pt_tables.py
+++ b/backend/migrations/add_pt_tables.py
@@ -1,0 +1,149 @@
+"""WODYBODY PT 모델 신규 테이블(user_preferences, daily_assignments, push_tokens)을 생성한다.
+
+PostgreSQL과 SQLite 양쪽에서 IDEMPOTENT하게 동작하도록 작성.
+사용법:
+    cd backend
+    python migrations/add_pt_tables.py
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from app import app, db  # noqa: E402
+from sqlalchemy import text  # noqa: E402
+
+
+PG_STATEMENTS = [
+    """
+    CREATE TABLE IF NOT EXISTS user_preferences (
+        id SERIAL PRIMARY KEY,
+        user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+        goals TEXT,
+        equipment TEXT,
+        available_minutes INTEGER DEFAULT 20,
+        difficulty VARCHAR(20) DEFAULT 'intermediate',
+        push_time VARCHAR(5) DEFAULT '09:00',
+        timezone VARCHAR(64) DEFAULT 'Asia/Seoul',
+        push_enabled BOOLEAN DEFAULT TRUE,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        CONSTRAINT user_preferences_user_uniq UNIQUE (user_id)
+    );
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_user_preferences_user_id ON user_preferences(user_id);",
+    """
+    CREATE TABLE IF NOT EXISTS daily_assignments (
+        id SERIAL PRIMARY KEY,
+        user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+        assignment_date DATE NOT NULL,
+        program_id INTEGER REFERENCES programs(id) ON DELETE SET NULL,
+        source VARCHAR(20) DEFAULT 'ai_grok',
+        ai_rationale TEXT,
+        intensity_hint VARCHAR(20),
+        duration_estimate_minutes INTEGER,
+        refresh_count INTEGER DEFAULT 0,
+        completed_at TIMESTAMP,
+        skipped_at TIMESTAMP,
+        feedback_json TEXT,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        CONSTRAINT uq_daily_assignments_user_date UNIQUE (user_id, assignment_date)
+    );
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_daily_assignments_user_date ON daily_assignments(user_id, assignment_date);",
+    """
+    CREATE TABLE IF NOT EXISTS push_tokens (
+        id SERIAL PRIMARY KEY,
+        user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+        platform VARCHAR(10) NOT NULL,
+        token VARCHAR(512) NOT NULL,
+        app_version VARCHAR(32),
+        last_seen_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        is_active BOOLEAN DEFAULT TRUE,
+        CONSTRAINT uq_push_tokens_user_token UNIQUE (user_id, token)
+    );
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_push_tokens_user ON push_tokens(user_id);",
+]
+
+
+SQLITE_STATEMENTS = [
+    """
+    CREATE TABLE IF NOT EXISTS user_preferences (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id INTEGER NOT NULL UNIQUE REFERENCES users(id) ON DELETE CASCADE,
+        goals TEXT,
+        equipment TEXT,
+        available_minutes INTEGER DEFAULT 20,
+        difficulty VARCHAR(20) DEFAULT 'intermediate',
+        push_time VARCHAR(5) DEFAULT '09:00',
+        timezone VARCHAR(64) DEFAULT 'Asia/Seoul',
+        push_enabled BOOLEAN DEFAULT 1,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    );
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_user_preferences_user_id ON user_preferences(user_id);",
+    """
+    CREATE TABLE IF NOT EXISTS daily_assignments (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+        assignment_date DATE NOT NULL,
+        program_id INTEGER REFERENCES programs(id) ON DELETE SET NULL,
+        source VARCHAR(20) DEFAULT 'ai_grok',
+        ai_rationale TEXT,
+        intensity_hint VARCHAR(20),
+        duration_estimate_minutes INTEGER,
+        refresh_count INTEGER DEFAULT 0,
+        completed_at TIMESTAMP,
+        skipped_at TIMESTAMP,
+        feedback_json TEXT,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        UNIQUE (user_id, assignment_date)
+    );
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_daily_assignments_user_date ON daily_assignments(user_id, assignment_date);",
+    """
+    CREATE TABLE IF NOT EXISTS push_tokens (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+        platform VARCHAR(10) NOT NULL,
+        token VARCHAR(512) NOT NULL,
+        app_version VARCHAR(32),
+        last_seen_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        is_active BOOLEAN DEFAULT 1,
+        UNIQUE (user_id, token)
+    );
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_push_tokens_user ON push_tokens(user_id);",
+]
+
+
+def is_postgres():
+    uri = app.config.get('SQLALCHEMY_DATABASE_URI', '')
+    return uri.startswith('postgres')
+
+
+def run():
+    statements = PG_STATEMENTS if is_postgres() else SQLITE_STATEMENTS
+    backend = 'PostgreSQL' if is_postgres() else 'SQLite'
+    print('=' * 60)
+    print(f'WODYBODY PT 테이블 마이그레이션 시작 ({backend})')
+    print('=' * 60)
+    with app.app_context():
+        for stmt in statements:
+            try:
+                db.session.execute(text(stmt))
+            except Exception as exc:
+                print(f'⚠️  실행 실패 (계속 진행): {exc}\n  SQL: {stmt[:80]}…')
+        db.session.commit()
+    print('✅ 마이그레이션 완료: user_preferences / daily_assignments / push_tokens')
+
+
+if __name__ == '__main__':
+    run()

--- a/backend/migrations/add_pt_tables.sql
+++ b/backend/migrations/add_pt_tables.sql
@@ -1,0 +1,51 @@
+-- WODYBODY PT 모델 신규 테이블 (PostgreSQL).
+-- IDEMPOTENT: CREATE IF NOT EXISTS / CREATE INDEX IF NOT EXISTS 사용.
+
+CREATE TABLE IF NOT EXISTS user_preferences (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    goals TEXT,
+    equipment TEXT,
+    available_minutes INTEGER DEFAULT 20,
+    difficulty VARCHAR(20) DEFAULT 'intermediate',
+    push_time VARCHAR(5) DEFAULT '09:00',
+    timezone VARCHAR(64) DEFAULT 'Asia/Seoul',
+    push_enabled BOOLEAN DEFAULT TRUE,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT user_preferences_user_uniq UNIQUE (user_id)
+);
+CREATE INDEX IF NOT EXISTS idx_user_preferences_user_id ON user_preferences(user_id);
+
+CREATE TABLE IF NOT EXISTS daily_assignments (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    assignment_date DATE NOT NULL,
+    program_id INTEGER REFERENCES programs(id) ON DELETE SET NULL,
+    source VARCHAR(20) DEFAULT 'ai_grok',
+    ai_rationale TEXT,
+    intensity_hint VARCHAR(20),
+    duration_estimate_minutes INTEGER,
+    refresh_count INTEGER DEFAULT 0,
+    completed_at TIMESTAMP,
+    skipped_at TIMESTAMP,
+    feedback_json TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uq_daily_assignments_user_date UNIQUE (user_id, assignment_date)
+);
+CREATE INDEX IF NOT EXISTS idx_daily_assignments_user_date
+    ON daily_assignments(user_id, assignment_date);
+
+CREATE TABLE IF NOT EXISTS push_tokens (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    platform VARCHAR(10) NOT NULL,
+    token VARCHAR(512) NOT NULL,
+    app_version VARCHAR(32),
+    last_seen_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    is_active BOOLEAN DEFAULT TRUE,
+    CONSTRAINT uq_push_tokens_user_token UNIQUE (user_id, token)
+);
+CREATE INDEX IF NOT EXISTS idx_push_tokens_user ON push_tokens(user_id);

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -4,11 +4,17 @@ from .program import Programs, Registrations, ProgramParticipants, PersonalGoals
 from .exercise import ExerciseCategories, Exercises, ProgramExercises, WorkoutPatterns, ExerciseSets
 from .notification import Notifications
 from .workout_record import WorkoutRecords
+from .preference import UserPreferences
+from .daily_assignment import DailyAssignments
+from .push_token import PushTokens
 
 __all__ = [
     'Users',
     'Programs', 'Registrations', 'ProgramParticipants', 'PersonalGoals',
     'ExerciseCategories', 'Exercises', 'ProgramExercises', 'WorkoutPatterns', 'ExerciseSets',
     'Notifications',
-    'WorkoutRecords'
+    'WorkoutRecords',
+    'UserPreferences',
+    'DailyAssignments',
+    'PushTokens',
 ]

--- a/backend/models/daily_assignment.py
+++ b/backend/models/daily_assignment.py
@@ -1,0 +1,97 @@
+"""일일 WOD 배정 모델 — (user_id, date) 단위 캐싱 + 피드백 저장."""
+
+from datetime import datetime
+import json
+
+from config.database import db
+from utils.timezone import get_korea_time
+
+
+class DailyAssignments(db.Model):
+    """매일 1행: 사용자에게 추천된 WOD와 실행 결과/피드백."""
+
+    __tablename__ = 'daily_assignments'
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(
+        db.Integer,
+        db.ForeignKey('users.id', ondelete='CASCADE'),
+        nullable=False,
+        index=True,
+    )
+    assignment_date = db.Column(db.Date, nullable=False, index=True)
+    program_id = db.Column(
+        db.Integer,
+        db.ForeignKey('programs.id', ondelete='SET NULL'),
+        nullable=True,
+    )
+    # 'ai_grok' | 'self_pick' | 'fallback'
+    source = db.Column(db.String(20), default='ai_grok')
+    ai_rationale = db.Column(db.Text)
+    intensity_hint = db.Column(db.String(20))
+    duration_estimate_minutes = db.Column(db.Integer)
+    refresh_count = db.Column(db.Integer, default=0)
+    completed_at = db.Column(db.DateTime)
+    skipped_at = db.Column(db.DateTime)
+    # JSON: { "user_feedback": "easy|hard|skip|refused", "client_meta": {...} }
+    feedback_json = db.Column(db.Text)
+    created_at = db.Column(db.DateTime, default=get_korea_time)
+    updated_at = db.Column(
+        db.DateTime, default=get_korea_time, onupdate=datetime.utcnow
+    )
+
+    user = db.relationship('Users', backref='daily_assignments')
+    program = db.relationship('Programs')
+
+    __table_args__ = (
+        db.UniqueConstraint(
+            'user_id', 'assignment_date', name='uq_daily_assignments_user_date'
+        ),
+        db.Index('idx_daily_assignments_user_date', 'user_id', 'assignment_date'),
+    )
+
+    def feedback_dict(self):
+        if not self.feedback_json:
+            return {}
+        try:
+            data = json.loads(self.feedback_json)
+            return data if isinstance(data, dict) else {}
+        except (TypeError, ValueError):
+            return {}
+
+    def set_feedback(self, payload):
+        self.feedback_json = json.dumps(payload, ensure_ascii=False)
+
+    def to_dict(self, include_program=False):
+        out = {
+            'id': self.id,
+            'user_id': self.user_id,
+            'assignment_date': (
+                self.assignment_date.isoformat() if self.assignment_date else None
+            ),
+            'program_id': self.program_id,
+            'source': self.source,
+            'ai_rationale': self.ai_rationale,
+            'intensity_hint': self.intensity_hint,
+            'duration_estimate_minutes': self.duration_estimate_minutes,
+            'refresh_count': self.refresh_count or 0,
+            'completed_at': (
+                self.completed_at.isoformat() if self.completed_at else None
+            ),
+            'skipped_at': self.skipped_at.isoformat() if self.skipped_at else None,
+            'feedback': self.feedback_dict(),
+            'created_at': self.created_at.isoformat() if self.created_at else None,
+            'updated_at': self.updated_at.isoformat() if self.updated_at else None,
+        }
+        if include_program and self.program is not None:
+            try:
+                out['program'] = self.program.to_dict()
+            except Exception:
+                out['program'] = None
+        return out
+
+    def __repr__(self):
+        return (
+            f'<DailyAssignment user={self.user_id} date={self.assignment_date} '
+            f'program={self.program_id} source={self.source}>'
+        )

--- a/backend/models/preference.py
+++ b/backend/models/preference.py
@@ -1,0 +1,84 @@
+"""사용자 PT 선호 설정 모델."""
+
+from datetime import datetime
+import json
+
+from config.database import db
+from utils.timezone import get_korea_time
+
+
+class UserPreferences(db.Model):
+    """사용자별 PT 선호 설정 (목표·기구·시간·난이도·푸시 시각)."""
+
+    __tablename__ = 'user_preferences'
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(
+        db.Integer,
+        db.ForeignKey('users.id', ondelete='CASCADE'),
+        nullable=False,
+        unique=True,
+        index=True,
+    )
+    # JSON-encoded list of strings, e.g. '["muscle_gain","conditioning"]'.
+    # SQLite/Postgres 양쪽에서 안전하도록 TEXT로 저장.
+    goals = db.Column(db.Text)
+    equipment = db.Column(db.Text)
+    available_minutes = db.Column(db.Integer, default=20)
+    difficulty = db.Column(db.String(20), default='intermediate')
+    push_time = db.Column(db.String(5), default='09:00')
+    timezone = db.Column(db.String(64), default='Asia/Seoul')
+    push_enabled = db.Column(db.Boolean, default=True)
+    created_at = db.Column(db.DateTime, default=get_korea_time)
+    updated_at = db.Column(
+        db.DateTime, default=get_korea_time, onupdate=datetime.utcnow
+    )
+
+    user = db.relationship('Users', backref=db.backref('preferences', uselist=False))
+
+    @staticmethod
+    def _parse_list(value):
+        if not value:
+            return []
+        try:
+            data = json.loads(value)
+            return data if isinstance(data, list) else []
+        except (TypeError, ValueError):
+            return []
+
+    def goals_list(self):
+        return self._parse_list(self.goals)
+
+    def equipment_list(self):
+        return self._parse_list(self.equipment)
+
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'user_id': self.user_id,
+            'goals': self.goals_list(),
+            'equipment': self.equipment_list(),
+            'available_minutes': self.available_minutes,
+            'difficulty': self.difficulty,
+            'push_time': self.push_time,
+            'timezone': self.timezone,
+            'push_enabled': self.push_enabled,
+            'created_at': self.created_at.isoformat() if self.created_at else None,
+            'updated_at': self.updated_at.isoformat() if self.updated_at else None,
+        }
+
+    @classmethod
+    def default_payload(cls):
+        """선호 설정 미입력 사용자에 대한 기본값."""
+        return {
+            'goals': ['general_fitness'],
+            'equipment': ['bodyweight'],
+            'available_minutes': 20,
+            'difficulty': 'intermediate',
+            'push_time': '09:00',
+            'timezone': 'Asia/Seoul',
+            'push_enabled': True,
+        }
+
+    def __repr__(self):
+        return f'<UserPreferences user={self.user_id} difficulty={self.difficulty}>'

--- a/backend/models/push_token.py
+++ b/backend/models/push_token.py
@@ -1,0 +1,55 @@
+"""푸시 토큰 모델 — iOS(APNs) / Android(FCM) / Web 디바이스 토큰 저장."""
+
+from datetime import datetime
+
+from config.database import db
+from utils.timezone import get_korea_time
+
+
+class PushTokens(db.Model):
+    """디바이스 토큰. (user_id, token) 유니크."""
+
+    __tablename__ = 'push_tokens'
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(
+        db.Integer,
+        db.ForeignKey('users.id', ondelete='CASCADE'),
+        nullable=False,
+        index=True,
+    )
+    # 'ios' | 'android' | 'web'
+    platform = db.Column(db.String(10), nullable=False)
+    token = db.Column(db.String(512), nullable=False)
+    app_version = db.Column(db.String(32))
+    last_seen_at = db.Column(db.DateTime, default=get_korea_time)
+    created_at = db.Column(db.DateTime, default=get_korea_time)
+    is_active = db.Column(db.Boolean, default=True)
+
+    user = db.relationship('Users', backref='push_tokens')
+
+    __table_args__ = (
+        db.UniqueConstraint('user_id', 'token', name='uq_push_tokens_user_token'),
+        db.Index('idx_push_tokens_user', 'user_id'),
+    )
+
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'user_id': self.user_id,
+            'platform': self.platform,
+            # 보안상 토큰 전체 미노출 — 앞 8자만.
+            'token_preview': (self.token or '')[:8] + '…',
+            'app_version': self.app_version,
+            'last_seen_at': (
+                self.last_seen_at.isoformat() if self.last_seen_at else None
+            ),
+            'created_at': self.created_at.isoformat() if self.created_at else None,
+            'is_active': bool(self.is_active),
+        }
+
+    def touch(self):
+        self.last_seen_at = datetime.utcnow()
+
+    def __repr__(self):
+        return f'<PushToken user={self.user_id} platform={self.platform}>'

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,3 +12,8 @@ gunicorn==21.2.0
 eventlet==0.33.3
 pytz==2023.3
 requests==2.32.3
+APScheduler==3.10.4
+# Optional — only needed if APNs/FCM 자격증명이 설정된 경우 실제 발송에 사용.
+# 설치되지 않아도 푸시 디스패처는 WARN 로그 후 no-op으로 동작한다.
+PyJWT[crypto]==2.8.0
+google-auth==2.32.0

--- a/backend/routes/preferences.py
+++ b/backend/routes/preferences.py
@@ -1,0 +1,120 @@
+"""사용자 PT 선호 설정 라우트.
+
+GET  /api/me/preferences  -> 현재 선호 (없으면 기본값 객체).
+PUT  /api/me/preferences  -> 선호 저장/갱신.
+"""
+
+import json
+
+from flask import Blueprint, request, jsonify, current_app
+
+from config.database import db
+from models.preference import UserPreferences
+
+
+bp = Blueprint('preferences', __name__, url_prefix='/api')
+
+
+def get_user_id_from_session_or_cookies():
+    from app import get_user_id_from_session_or_cookies as get_user_id
+    return get_user_id()
+
+
+VALID_DIFFICULTIES = {'beginner', 'intermediate', 'advanced'}
+
+
+def _coerce_list(value):
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [str(v).strip() for v in value if str(v).strip()]
+    if isinstance(value, str):
+        try:
+            data = json.loads(value)
+            if isinstance(data, list):
+                return [str(v).strip() for v in data if str(v).strip()]
+        except (TypeError, ValueError):
+            pass
+    return []
+
+
+def _serialize(pref: UserPreferences | None) -> dict:
+    if pref is not None:
+        return pref.to_dict()
+    payload = UserPreferences.default_payload()
+    return {
+        'id': None,
+        'user_id': None,
+        **payload,
+        'created_at': None,
+        'updated_at': None,
+    }
+
+
+@bp.route('/me/preferences', methods=['GET'])
+def get_preferences():
+    user_id = get_user_id_from_session_or_cookies()
+    if not user_id:
+        return jsonify({'message': '로그인이 필요합니다'}), 401
+
+    pref = UserPreferences.query.filter_by(user_id=user_id).first()
+    return jsonify(_serialize(pref)), 200
+
+
+@bp.route('/me/preferences', methods=['PUT', 'POST'])
+def upsert_preferences():
+    user_id = get_user_id_from_session_or_cookies()
+    if not user_id:
+        return jsonify({'message': '로그인이 필요합니다'}), 401
+
+    body = request.get_json(silent=True) or {}
+
+    goals = _coerce_list(body.get('goals'))
+    equipment = _coerce_list(body.get('equipment'))
+    available_minutes = body.get('available_minutes')
+    difficulty = (body.get('difficulty') or '').strip() or None
+    push_time = (body.get('push_time') or '').strip() or None
+    timezone = (body.get('timezone') or '').strip() or None
+    push_enabled = body.get('push_enabled')
+
+    try:
+        if available_minutes is not None:
+            available_minutes = int(available_minutes)
+            if available_minutes <= 0 or available_minutes > 240:
+                return jsonify({'message': 'available_minutes 값이 유효하지 않습니다 (1~240)'}), 400
+    except (TypeError, ValueError):
+        return jsonify({'message': 'available_minutes는 정수여야 합니다'}), 400
+
+    if difficulty and difficulty not in VALID_DIFFICULTIES:
+        return jsonify({'message': f"difficulty는 {sorted(VALID_DIFFICULTIES)} 중 하나여야 합니다"}), 400
+
+    if push_time and (len(push_time) != 5 or push_time[2] != ':'):
+        return jsonify({'message': 'push_time은 HH:MM 형식이어야 합니다'}), 400
+
+    try:
+        pref = UserPreferences.query.filter_by(user_id=user_id).first()
+        if pref is None:
+            pref = UserPreferences(user_id=user_id)
+            db.session.add(pref)
+
+        if 'goals' in body:
+            pref.goals = json.dumps(goals, ensure_ascii=False)
+        if 'equipment' in body:
+            pref.equipment = json.dumps(equipment, ensure_ascii=False)
+        if available_minutes is not None:
+            pref.available_minutes = available_minutes
+        if difficulty:
+            pref.difficulty = difficulty
+        if push_time:
+            pref.push_time = push_time
+        if timezone:
+            pref.timezone = timezone
+        if push_enabled is not None:
+            pref.push_enabled = bool(push_enabled)
+
+        db.session.commit()
+        return jsonify(pref.to_dict()), 200
+    except Exception as e:
+        db.session.rollback()
+        current_app.logger.exception('upsert_preferences error: %s', e)
+        return jsonify({'message': '선호 저장 중 오류가 발생했습니다'}), 500

--- a/backend/routes/programs.py
+++ b/backend/routes/programs.py
@@ -1,5 +1,7 @@
 """프로그램 관련 라우트"""
 
+import os
+
 from flask import Blueprint, request, jsonify, session, current_app
 from config.database import db
 from models.program import Programs, Registrations, ProgramParticipants
@@ -12,6 +14,25 @@ from datetime import datetime, timedelta
 
 # 블루프린트 생성
 bp = Blueprint('programs', __name__, url_prefix='/api')
+
+
+# ==================================================================
+# 마켓플레이스 기능 플래그 (PT 모델로 전환되며 deprecate)
+# ==================================================================
+# 환경변수 MARKETPLACE_ENABLED=true 면 기존 마켓플레이스 라우트가 부활.
+# 기본값 false: /open, /join, /leave, /participants(...), /results, /approve 는 410 Gone.
+MARKETPLACE_ENABLED = os.environ.get('MARKETPLACE_ENABLED', 'false').lower() == 'true'
+
+
+def _gone_if_marketplace_disabled():
+    """마켓플레이스가 비활성화된 경우 410 Gone 응답을 반환. 활성화면 None."""
+    if not MARKETPLACE_ENABLED:
+        return jsonify({
+            'error': 'gone',
+            'message': '공개 마켓플레이스 기능은 PT 모델로 전환되어 종료되었습니다.',
+            'replacement': '/api/today'
+        }), 410
+    return None
 
 @bp.route('/programs', methods=['GET'])
 def get_programs():
@@ -298,7 +319,10 @@ def create_program():
 
 @bp.route('/programs/<int:program_id>/open', methods=['POST'])
 def open_program(program_id):
-    """프로그램 공개"""
+    """[DEPRECATED] 프로그램 공개 — 마켓플레이스 deprecate."""
+    gone = _gone_if_marketplace_disabled()
+    if gone is not None:
+        return gone
     try:
         user_id = get_user_id_from_session_or_cookies()
         if not user_id:
@@ -380,7 +404,10 @@ def open_program(program_id):
 
 @bp.route('/programs/<int:program_id>/join', methods=['POST'])
 def join_program(program_id):
-    """프로그램 참여 신청"""
+    """[DEPRECATED] 프로그램 참여 신청 — 마켓플레이스 deprecate."""
+    gone = _gone_if_marketplace_disabled()
+    if gone is not None:
+        return gone
     try:
         user_id = get_user_id_from_session_or_cookies()
         if not user_id:
@@ -434,7 +461,10 @@ def join_program(program_id):
 
 @bp.route('/programs/<int:program_id>/leave', methods=['DELETE'])
 def leave_program(program_id):
-    """프로그램 참여 취소"""
+    """[DEPRECATED] 프로그램 참여 취소 — 마켓플레이스 deprecate."""
+    gone = _gone_if_marketplace_disabled()
+    if gone is not None:
+        return gone
     try:
         user_id = get_user_id_from_session_or_cookies()
         if not user_id:
@@ -459,7 +489,10 @@ def leave_program(program_id):
 
 @bp.route('/programs/<int:program_id>/participants', methods=['GET'])
 def get_program_participants(program_id):
-    """프로그램 참여자 목록 조회"""
+    """[DEPRECATED] 프로그램 참여자 목록 조회 — 마켓플레이스 deprecate."""
+    gone = _gone_if_marketplace_disabled()
+    if gone is not None:
+        return gone
     try:
         user_id = get_user_id_from_session_or_cookies()
         if not user_id:
@@ -499,7 +532,10 @@ def get_program_participants(program_id):
 
 @bp.route('/programs/<int:program_id>/participants/<int:user_id>/approve', methods=['PUT'])
 def approve_participant(program_id, user_id):
-    """참여자 승인/거부"""
+    """[DEPRECATED] 참여자 승인/거부 — 마켓플레이스 deprecate."""
+    gone = _gone_if_marketplace_disabled()
+    if gone is not None:
+        return gone
     try:
         creator_id = get_user_id_from_session_or_cookies()
         if not creator_id:
@@ -559,7 +595,10 @@ def approve_participant(program_id, user_id):
 
 @bp.route('/programs/<int:program_id>/results', methods=['GET'])
 def program_results(program_id):
-    """프로그램 결과 조회"""
+    """[DEPRECATED] 프로그램 결과 조회 — 마켓플레이스 deprecate."""
+    gone = _gone_if_marketplace_disabled()
+    if gone is not None:
+        return gone
     try:
         user_id = get_user_id_from_session_or_cookies()
         if not user_id:

--- a/backend/routes/push.py
+++ b/backend/routes/push.py
@@ -1,0 +1,95 @@
+"""푸시 토큰 등록/해제 라우트.
+
+POST   /api/me/push-tokens         { platform, token, app_version? }
+DELETE /api/me/push-tokens/<id>    토큰 비활성화
+GET    /api/me/push-tokens         자기 디바이스 목록 (preview only)
+"""
+
+from datetime import datetime
+
+from flask import Blueprint, request, jsonify, current_app
+
+from config.database import db
+from models.push_token import PushTokens
+
+
+bp = Blueprint('push', __name__, url_prefix='/api/me')
+
+
+VALID_PLATFORMS = {'ios', 'android', 'web'}
+
+
+def get_user_id_from_session_or_cookies():
+    from app import get_user_id_from_session_or_cookies as get_user_id
+    return get_user_id()
+
+
+@bp.route('/push-tokens', methods=['GET'])
+def list_push_tokens():
+    user_id = get_user_id_from_session_or_cookies()
+    if not user_id:
+        return jsonify({'message': '로그인이 필요합니다'}), 401
+    tokens = (
+        PushTokens.query.filter_by(user_id=user_id, is_active=True)
+        .order_by(PushTokens.last_seen_at.desc().nullslast())
+        .all()
+    )
+    return jsonify({'tokens': [t.to_dict() for t in tokens]}), 200
+
+
+@bp.route('/push-tokens', methods=['POST'])
+def register_push_token():
+    user_id = get_user_id_from_session_or_cookies()
+    if not user_id:
+        return jsonify({'message': '로그인이 필요합니다'}), 401
+    body = request.get_json(silent=True) or {}
+    platform = (body.get('platform') or '').strip().lower()
+    token = (body.get('token') or '').strip()
+    app_version = (body.get('app_version') or '').strip() or None
+
+    if platform not in VALID_PLATFORMS:
+        return jsonify({'message': f"platform은 {sorted(VALID_PLATFORMS)} 중 하나여야 합니다"}), 400
+    if not token or len(token) < 8:
+        return jsonify({'message': '유효한 token이 필요합니다'}), 400
+
+    try:
+        existing = PushTokens.query.filter_by(user_id=user_id, token=token).first()
+        if existing is None:
+            existing = PushTokens(
+                user_id=user_id,
+                platform=platform,
+                token=token,
+                app_version=app_version,
+                is_active=True,
+            )
+            db.session.add(existing)
+        else:
+            existing.platform = platform
+            existing.app_version = app_version or existing.app_version
+            existing.is_active = True
+            existing.touch()
+        db.session.commit()
+        return jsonify({'message': '푸시 토큰이 등록되었습니다', 'token': existing.to_dict()}), 200
+    except Exception as e:
+        db.session.rollback()
+        current_app.logger.exception('register_push_token error: %s', e)
+        return jsonify({'message': '푸시 토큰 등록 중 오류가 발생했습니다'}), 500
+
+
+@bp.route('/push-tokens/<int:token_id>', methods=['DELETE'])
+def deactivate_push_token(token_id: int):
+    user_id = get_user_id_from_session_or_cookies()
+    if not user_id:
+        return jsonify({'message': '로그인이 필요합니다'}), 401
+    pt = PushTokens.query.filter_by(id=token_id, user_id=user_id).first()
+    if pt is None:
+        return jsonify({'message': '토큰을 찾을 수 없습니다'}), 404
+    try:
+        pt.is_active = False
+        pt.last_seen_at = datetime.utcnow()
+        db.session.commit()
+        return jsonify({'message': '푸시 토큰이 비활성화되었습니다'}), 200
+    except Exception as e:
+        db.session.rollback()
+        current_app.logger.exception('deactivate_push_token error: %s', e)
+        return jsonify({'message': '푸시 토큰 비활성화 중 오류가 발생했습니다'}), 500

--- a/backend/routes/recommendations.py
+++ b/backend/routes/recommendations.py
@@ -1,0 +1,506 @@
+"""Grok 기반 일일 WOD 추천 엔진.
+
+- 외부 API: xAI Grok (OpenAI 호환 chat/completions). burnfat_ai.py 의 호출 패턴을 재사용.
+- 캐싱: (user_id, assignment_date) 단위로 daily_assignments 테이블에 1행.
+- 라우트:
+    POST /api/recommendations/generate  (내부/디버그용)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import random
+from datetime import date as date_cls, datetime, timedelta
+from typing import Any
+
+import requests
+from flask import Blueprint, jsonify, request, current_app
+
+from config.database import db
+from models.daily_assignment import DailyAssignments
+from models.preference import UserPreferences
+from models.program import Programs
+from models.workout_record import WorkoutRecords
+from models.exercise import ProgramExercises, WorkoutPatterns, ExerciseSets
+
+
+bp = Blueprint('recommendations', __name__, url_prefix='/api')
+
+logger = logging.getLogger(__name__)
+
+XAI_API_URL = "https://api.x.ai/v1/chat/completions"
+XAI_MODEL = os.environ.get("XAI_MODEL", "grok-4-1-fast-non-reasoning")
+XAI_MAX_TOKENS = int(os.environ.get("XAI_MAX_TOKENS_RECOMMEND", "300"))
+XAI_TIMEOUT_SECONDS = int(os.environ.get("XAI_TIMEOUT_SECONDS", "30"))
+
+DAILY_REFRESH_LIMIT = int(os.environ.get('PT_DAILY_REFRESH_LIMIT', '3'))
+CANDIDATE_POOL_LIMIT = int(os.environ.get('PT_CANDIDATE_POOL_LIMIT', '30'))
+
+
+SYSTEM_PROMPT = """당신은 사용자에게 매일 1개의 운동(WOD)을 추천하는 개인 PT 코치입니다.
+사용자 데이터(선호·과거 기록·직전 7일 추천 이력)와 후보 WOD 목록을 보고,
+오늘 가장 적합한 WOD 하나를 골라 program_id로 지정하세요.
+
+## 선택 원칙
+1. 사용자의 goals와 equipment에 부합하는 WOD를 우선합니다.
+   - equipment에 없는 기구가 메인이면 후보에서 제외하세요.
+2. preferences.available_minutes의 ±25% 범위에 들어오는 WOD를 우선합니다.
+3. preferences.difficulty와 일치 또는 한 단계 차이만 허용.
+4. 직전 7일에 이미 추천된 program_id는 절대 다시 고르지 마세요.
+5. recent_records로 보아 평균 완료 시간이 목표 시간보다 짧다면 난이도를 한 단계 올리고,
+   길거나 스킵이 많다면 한 단계 내리세요.
+6. 직전 user_feedback이 "easy"면 강도를 올리고, "hard" 또는 "skip"이면 회복 강도로 추천.
+7. 후보가 부족하거나 모두 부적합하면 program_id를 null로 반환하고
+   rationale에 그 이유를 한국어 1문장으로 적으세요.
+
+## 출력 형식 (반드시 JSON 한 줄만)
+{
+  "program_id": <number | null>,
+  "rationale": "<한국어 1~2문장>",
+  "intensity_hint": "<easy|moderate|hard>",
+  "duration_estimate_minutes": <number>
+}
+
+규칙:
+- 반드시 JSON 객체 하나만 출력. 마크다운/설명/코드 블록 금지.
+- rationale은 사용자가 운동 직전에 읽을 톤(친근하고 실용적). 가능하면 수치 인용.
+"""
+
+
+# --------------------------------------------------------------------
+# 컨텍스트 빌더
+# --------------------------------------------------------------------
+
+
+def _today_for_user(pref: UserPreferences | None) -> date_cls:
+    """사용자 timezone 기준 오늘 날짜."""
+    try:
+        import pytz
+        tz = pytz.timezone(pref.timezone if (pref and pref.timezone) else 'Asia/Seoul')
+        return datetime.now(tz).date()
+    except Exception:
+        return date_cls.today()
+
+
+def _serialize_program(p: Programs) -> dict[str, Any]:
+    """Grok에 전달할 후보 WOD 한 줄 요약."""
+    pattern = WorkoutPatterns.query.filter_by(program_id=p.id).first()
+    expected_minutes = None
+    pattern_type = None
+    total_rounds = None
+    if pattern is not None:
+        pattern_type = pattern.pattern_type
+        total_rounds = pattern.total_rounds
+        if pattern.time_cap_per_round and pattern.total_rounds:
+            expected_minutes = pattern.time_cap_per_round * pattern.total_rounds
+        elif pattern.time_cap_per_round:
+            expected_minutes = pattern.time_cap_per_round
+
+    exercises: list[dict[str, Any]] = []
+    if pattern is not None:
+        sets = (
+            ExerciseSets.query.filter_by(pattern_id=pattern.id)
+            .order_by(ExerciseSets.order_index)
+            .limit(8)
+            .all()
+        )
+        for s in sets:
+            exercises.append({
+                'name': s.exercise.name if s.exercise else '',
+                'reps': s.base_reps,
+                'progression': s.progression_type,
+            })
+    if not exercises:
+        prog_ex = (
+            ProgramExercises.query.filter_by(program_id=p.id)
+            .order_by(ProgramExercises.order_index)
+            .limit(8)
+            .all()
+        )
+        for pe in prog_ex:
+            exercises.append({
+                'name': pe.exercise.name if pe.exercise else '',
+                'target_value': pe.target_value,
+            })
+
+    return {
+        'id': p.id,
+        'title': p.title,
+        'difficulty': p.difficulty,
+        'pattern_type': pattern_type,
+        'total_rounds': total_rounds,
+        'expected_minutes': expected_minutes,
+        'exercises': exercises,
+    }
+
+
+def _build_context(
+    user_id: int,
+    today: date_cls,
+    pref: UserPreferences | None,
+    candidate_programs: list[Programs],
+    recent_assignments: list[DailyAssignments],
+    recent_records: list[WorkoutRecords],
+) -> dict[str, Any]:
+    pref_dict = pref.to_dict() if pref else {
+        'goals': UserPreferences.default_payload()['goals'],
+        'equipment': UserPreferences.default_payload()['equipment'],
+        'available_minutes': UserPreferences.default_payload()['available_minutes'],
+        'difficulty': UserPreferences.default_payload()['difficulty'],
+    }
+
+    # 직전 5개 기록은 상세, 나머지는 요약 통계로 (토큰 절약).
+    detail_records = recent_records[:5]
+    record_details = [
+        {
+            'date': r.completed_at.isoformat() if r.completed_at else None,
+            'program_id': r.program_id,
+            'completion_minutes': round((r.completion_time or 0) / 60.0, 1),
+        }
+        for r in detail_records
+    ]
+
+    skipped_count = sum(1 for a in recent_assignments if a.skipped_at)
+    completed_count = sum(1 for a in recent_assignments if a.completed_at)
+
+    return {
+        'today': today.isoformat(),
+        'preferences': {
+            'goals': pref_dict.get('goals', []),
+            'equipment': pref_dict.get('equipment', []),
+            'available_minutes': pref_dict.get('available_minutes', 20),
+            'difficulty': pref_dict.get('difficulty', 'intermediate'),
+        },
+        'recent_assignments': [
+            {
+                'date': a.assignment_date.isoformat() if a.assignment_date else None,
+                'program_id': a.program_id,
+                'completed': bool(a.completed_at),
+                'skipped': bool(a.skipped_at),
+                'user_feedback': a.feedback_dict().get('user_feedback'),
+                'intensity_hint': a.intensity_hint,
+            }
+            for a in recent_assignments
+        ],
+        'recent_assignments_summary': {
+            'completed_count_7d': completed_count,
+            'skipped_count_7d': skipped_count,
+        },
+        'recent_records_summary': {
+            'count_30d': len(recent_records),
+            'avg_completion_minutes': round(
+                sum((r.completion_time or 0) for r in recent_records) / 60.0
+                / max(len(recent_records), 1),
+                1,
+            ) if recent_records else None,
+            'last_5_records': record_details,
+        },
+        'available_programs': [_serialize_program(p) for p in candidate_programs],
+    }
+
+
+# --------------------------------------------------------------------
+# 후보 풀 수집
+# --------------------------------------------------------------------
+
+
+def _collect_candidate_programs(
+    user_id: int, exclude_program_ids: set[int]
+) -> list[Programs]:
+    """사용자 본인 + 공개 풀에서 후보를 모은다."""
+    candidates: dict[int, Programs] = {}
+
+    # 1) 사용자 본인이 만든 프로그램
+    own = Programs.query.filter_by(creator_id=user_id).limit(CANDIDATE_POOL_LIMIT).all()
+    for p in own:
+        if p.id not in exclude_program_ids:
+            candidates[p.id] = p
+
+    remaining = max(0, CANDIDATE_POOL_LIMIT - len(candidates))
+    if remaining > 0:
+        # 2) 공개 풀 (마켓플레이스가 deprecate되었지만 데이터는 후보로 사용 가능)
+        try:
+            opened = (
+                Programs.query.filter(
+                    Programs.creator_id != user_id,
+                    Programs.is_open.is_(True),
+                )
+                .order_by(Programs.created_at.desc())
+                .limit(remaining * 2)
+                .all()
+            )
+        except Exception:
+            opened = []
+        for p in opened:
+            if p.id in exclude_program_ids or p.id in candidates:
+                continue
+            candidates[p.id] = p
+            if len(candidates) >= CANDIDATE_POOL_LIMIT:
+                break
+
+    # 3) 그래도 부족하면 전체 프로그램 중 무작위 보충 (콜드스타트)
+    if len(candidates) < 5:
+        try:
+            extras = (
+                Programs.query.filter(Programs.creator_id != user_id)
+                .order_by(Programs.created_at.desc())
+                .limit(CANDIDATE_POOL_LIMIT)
+                .all()
+            )
+        except Exception:
+            extras = []
+        for p in extras:
+            if p.id in exclude_program_ids or p.id in candidates:
+                continue
+            candidates[p.id] = p
+            if len(candidates) >= CANDIDATE_POOL_LIMIT:
+                break
+
+    return list(candidates.values())
+
+
+# --------------------------------------------------------------------
+# Grok 호출 + 응답 검증
+# --------------------------------------------------------------------
+
+
+def _call_grok(context: dict[str, Any]) -> dict[str, Any]:
+    """Grok 호출. 키 미설정/네트워크 에러는 RuntimeError 또는 RequestException."""
+    api_key = os.environ.get("XAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("XAI_API_KEY not configured")
+
+    user_content = (
+        "다음 컨텍스트를 보고 오늘의 추천을 JSON 한 줄로 반환하세요.\n\n"
+        + json.dumps(context, ensure_ascii=False, indent=2)
+    )
+    payload = {
+        "model": XAI_MODEL,
+        "messages": [
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": user_content},
+        ],
+        "max_tokens": XAI_MAX_TOKENS,
+        "temperature": 0.6,
+        "response_format": {"type": "json_object"},
+    }
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+    resp = requests.post(
+        XAI_API_URL, json=payload, headers=headers, timeout=XAI_TIMEOUT_SECONDS
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    choices = data.get("choices") or []
+    if not choices:
+        raise RuntimeError("Grok response had no choices")
+    content = ((choices[0].get("message") or {}).get("content") or "").strip()
+    if not content:
+        raise RuntimeError("Grok response content was empty")
+
+    return _parse_grok_response(content)
+
+
+def _parse_grok_response(text: str) -> dict[str, Any]:
+    """JSON 한 객체를 파싱. 실패 시 빈 딕트 + program_id None."""
+    try:
+        # 일부 모델이 코드 블록으로 감싸는 경우 제거
+        cleaned = text.strip()
+        if cleaned.startswith("```"):
+            cleaned = cleaned.strip('`')
+            # ``` json {...} ``` 같이 들어오면 첫 줄 제거
+            if cleaned.lstrip().lower().startswith('json'):
+                cleaned = cleaned.split('\n', 1)[-1]
+        data = json.loads(cleaned)
+        if not isinstance(data, dict):
+            return {}
+        return data
+    except (TypeError, ValueError):
+        return {}
+
+
+def _fallback_pick(candidates: list[Programs]) -> tuple[int | None, str]:
+    if not candidates:
+        return None, '오늘 추천할 수 있는 후보 WOD가 부족합니다. 라이브러리에 새 WOD를 추가하거나 잠시 후 다시 시도해 주세요.'
+    pick = random.choice(candidates)
+    return pick.id, '오늘은 가용 후보 중 무작위로 선정했습니다. 가볍게 몸을 풀어보세요.'
+
+
+# --------------------------------------------------------------------
+# 핵심 엔트리 포인트
+# --------------------------------------------------------------------
+
+
+def generate_recommendation(
+    user_id: int,
+    today: date_cls | None = None,
+    *,
+    force_refresh: bool = False,
+) -> DailyAssignments:
+    """
+    (user_id, today) 행을 반환. 없으면 새로 생성. force_refresh=True면 신규 추천 추가.
+
+    반환: DailyAssignments (commit 완료된 객체).
+    """
+    pref = UserPreferences.query.filter_by(user_id=user_id).first()
+    if today is None:
+        today = _today_for_user(pref)
+
+    existing = (
+        DailyAssignments.query.filter_by(user_id=user_id, assignment_date=today).first()
+    )
+
+    # 캐시 적중
+    if existing is not None and not force_refresh:
+        return existing
+
+    # 직전 7일 + 기존 같은 날 추천 program_id 모두 anti-repeat에 포함
+    cutoff = today - timedelta(days=7)
+    history = (
+        DailyAssignments.query.filter(
+            DailyAssignments.user_id == user_id,
+            DailyAssignments.assignment_date >= cutoff,
+        )
+        .order_by(DailyAssignments.assignment_date.desc())
+        .all()
+    )
+    exclude_ids: set[int] = {a.program_id for a in history if a.program_id}
+    if existing is not None and existing.program_id:
+        exclude_ids.add(existing.program_id)
+
+    candidates = _collect_candidate_programs(user_id, exclude_ids)
+    candidate_id_set = {p.id for p in candidates}
+
+    recent_records = (
+        WorkoutRecords.query.filter(
+            WorkoutRecords.user_id == user_id,
+            WorkoutRecords.completed_at >= datetime.utcnow() - timedelta(days=30),
+        )
+        .order_by(WorkoutRecords.completed_at.desc())
+        .limit(50)
+        .all()
+    )
+
+    context = _build_context(
+        user_id=user_id,
+        today=today,
+        pref=pref,
+        candidate_programs=candidates,
+        recent_assignments=history,
+        recent_records=recent_records,
+    )
+
+    program_id: int | None = None
+    rationale = ''
+    intensity_hint = 'moderate'
+    duration_estimate = (pref.available_minutes if pref and pref.available_minutes else 20)
+    source = 'ai_grok'
+
+    try:
+        parsed = _call_grok(context)
+        program_id = parsed.get('program_id')
+        if isinstance(program_id, str):
+            try:
+                program_id = int(program_id)
+            except (TypeError, ValueError):
+                program_id = None
+        if program_id is not None and program_id not in candidate_id_set:
+            current_app.logger.warning(
+                'Grok suggested program_id=%s not in candidate set; falling back', program_id
+            )
+            program_id = None
+        rationale = (parsed.get('rationale') or '').strip()[:300]
+        intensity_hint = (parsed.get('intensity_hint') or 'moderate').strip()[:20]
+        try:
+            duration_estimate = int(parsed.get('duration_estimate_minutes') or duration_estimate)
+        except (TypeError, ValueError):
+            pass
+    except RuntimeError as e:
+        current_app.logger.warning('Grok unavailable, using fallback: %s', e)
+        source = 'fallback'
+    except requests.RequestException as e:
+        current_app.logger.warning('Grok request failed, using fallback: %s', e)
+        source = 'fallback'
+    except Exception as e:
+        current_app.logger.exception('Unexpected Grok error: %s', e)
+        source = 'fallback'
+
+    if program_id is None:
+        fallback_id, fallback_reason = _fallback_pick(candidates)
+        program_id = fallback_id
+        if not rationale:
+            rationale = fallback_reason
+        if source == 'ai_grok':
+            source = 'fallback'
+
+    if existing is None:
+        existing = DailyAssignments(
+            user_id=user_id,
+            assignment_date=today,
+            program_id=program_id,
+            source=source,
+            ai_rationale=rationale,
+            intensity_hint=intensity_hint,
+            duration_estimate_minutes=duration_estimate,
+            refresh_count=0,
+        )
+        db.session.add(existing)
+    else:
+        # refresh: 직전 program_id를 refused로 마킹
+        prev_feedback = existing.feedback_dict()
+        prev_feedback['previous_program_ids'] = (
+            prev_feedback.get('previous_program_ids', []) + [existing.program_id]
+        )
+        prev_feedback['user_feedback'] = 'refused'
+        existing.set_feedback(prev_feedback)
+        existing.program_id = program_id
+        existing.source = source
+        existing.ai_rationale = rationale
+        existing.intensity_hint = intensity_hint
+        existing.duration_estimate_minutes = duration_estimate
+        existing.refresh_count = (existing.refresh_count or 0) + 1
+        existing.completed_at = None
+        existing.skipped_at = None
+
+    db.session.commit()
+    return existing
+
+
+def get_user_id_from_session_or_cookies():
+    from app import get_user_id_from_session_or_cookies as get_user_id
+    return get_user_id()
+
+
+# --------------------------------------------------------------------
+# 디버그 라우트 (운영 모니터링/테스트용)
+# --------------------------------------------------------------------
+
+
+@bp.route('/recommendations/generate', methods=['POST'])
+def recommendations_generate():
+    """현재 사용자의 오늘 추천을 생성/조회. 디버그·내부 호출용."""
+    user_id = get_user_id_from_session_or_cookies()
+    if not user_id:
+        return jsonify({'message': '로그인이 필요합니다'}), 401
+    body = request.get_json(silent=True) or {}
+    force = bool(body.get('force_refresh'))
+    try:
+        assignment = generate_recommendation(user_id, force_refresh=force)
+    except Exception as e:
+        current_app.logger.exception('recommendations_generate error: %s', e)
+        return jsonify({'message': '추천 생성 중 오류가 발생했습니다'}), 500
+    return jsonify(assignment.to_dict(include_program=True)), 200
+
+
+@bp.route('/recommendations/health', methods=['GET'])
+def recommendations_health():
+    return jsonify({
+        'xai_configured': bool(os.environ.get('XAI_API_KEY')),
+        'model': XAI_MODEL,
+        'daily_refresh_limit': DAILY_REFRESH_LIMIT,
+        'candidate_pool_limit': CANDIDATE_POOL_LIMIT,
+    }), 200

--- a/backend/routes/today.py
+++ b/backend/routes/today.py
@@ -1,0 +1,189 @@
+"""오늘의 WOD 라우트.
+
+GET  /api/today              -> 오늘 배정 조회 (없으면 생성)
+POST /api/today/refresh      -> "다른 추천" — 일 N회 한도
+POST /api/today/complete     -> 완료 마킹 + workout_records INSERT
+POST /api/today/skip         -> 스킵 마킹
+POST /api/today/feedback     -> easy/hard 피드백 (Phase 4)
+"""
+
+from datetime import datetime
+
+from flask import Blueprint, request, jsonify, current_app
+
+from config.database import db
+from models.daily_assignment import DailyAssignments
+from models.workout_record import WorkoutRecords
+from models.preference import UserPreferences
+from routes.recommendations import (
+    generate_recommendation,
+    DAILY_REFRESH_LIMIT,
+    _today_for_user,
+)
+
+
+bp = Blueprint('today', __name__, url_prefix='/api/today')
+
+
+def get_user_id_from_session_or_cookies():
+    from app import get_user_id_from_session_or_cookies as get_user_id
+    return get_user_id()
+
+
+def _serialize_assignment(a: DailyAssignments) -> dict:
+    payload = a.to_dict(include_program=True)
+    payload['daily_refresh_limit'] = DAILY_REFRESH_LIMIT
+    payload['can_refresh'] = (a.refresh_count or 0) < DAILY_REFRESH_LIMIT
+    return payload
+
+
+@bp.route('', methods=['GET'])
+@bp.route('/', methods=['GET'])
+def get_today():
+    user_id = get_user_id_from_session_or_cookies()
+    if not user_id:
+        return jsonify({'message': '로그인이 필요합니다'}), 401
+    try:
+        assignment = generate_recommendation(user_id)
+        return jsonify(_serialize_assignment(assignment)), 200
+    except Exception as e:
+        current_app.logger.exception('get_today error: %s', e)
+        return jsonify({'message': '오늘의 추천을 가져오는 중 오류가 발생했습니다'}), 500
+
+
+@bp.route('/refresh', methods=['POST'])
+def refresh_today():
+    user_id = get_user_id_from_session_or_cookies()
+    if not user_id:
+        return jsonify({'message': '로그인이 필요합니다'}), 401
+
+    pref = UserPreferences.query.filter_by(user_id=user_id).first()
+    today = _today_for_user(pref)
+    existing = (
+        DailyAssignments.query.filter_by(user_id=user_id, assignment_date=today).first()
+    )
+    if existing is not None and (existing.refresh_count or 0) >= DAILY_REFRESH_LIMIT:
+        return jsonify({
+            'message': f'오늘은 추천 새로받기 한도({DAILY_REFRESH_LIMIT}회)를 초과했습니다.',
+            'limit': DAILY_REFRESH_LIMIT,
+            'refresh_count': existing.refresh_count or 0,
+        }), 429
+
+    try:
+        assignment = generate_recommendation(user_id, today=today, force_refresh=True)
+        return jsonify(_serialize_assignment(assignment)), 200
+    except Exception as e:
+        current_app.logger.exception('refresh_today error: %s', e)
+        return jsonify({'message': '추천 새로받기 중 오류가 발생했습니다'}), 500
+
+
+@bp.route('/complete', methods=['POST'])
+def complete_today():
+    user_id = get_user_id_from_session_or_cookies()
+    if not user_id:
+        return jsonify({'message': '로그인이 필요합니다'}), 401
+
+    body = request.get_json(silent=True) or {}
+    completion_time = body.get('completion_time')
+    notes = body.get('notes') or ''
+
+    if completion_time is None:
+        return jsonify({'message': 'completion_time(초)이 필요합니다'}), 400
+    try:
+        completion_time = int(completion_time)
+        if completion_time <= 0:
+            raise ValueError
+    except (TypeError, ValueError):
+        return jsonify({'message': 'completion_time은 양의 정수(초)여야 합니다'}), 400
+
+    pref = UserPreferences.query.filter_by(user_id=user_id).first()
+    today = _today_for_user(pref)
+    assignment = (
+        DailyAssignments.query.filter_by(user_id=user_id, assignment_date=today).first()
+    )
+    if assignment is None or assignment.program_id is None:
+        return jsonify({'message': '오늘의 배정 WOD가 없습니다'}), 404
+
+    try:
+        assignment.completed_at = datetime.utcnow()
+        assignment.skipped_at = None
+
+        # workout_records INSERT (기존 기록 시스템과 호환)
+        record = WorkoutRecords(
+            program_id=assignment.program_id,
+            user_id=user_id,
+            completion_time=completion_time,
+            notes=notes,
+            is_public=False,
+            completed_at=datetime.utcnow(),
+        )
+        db.session.add(record)
+        db.session.commit()
+        return jsonify({
+            'message': '완료 기록이 저장되었습니다',
+            'record_id': record.id,
+            'assignment': _serialize_assignment(assignment),
+        }), 200
+    except Exception as e:
+        db.session.rollback()
+        current_app.logger.exception('complete_today error: %s', e)
+        return jsonify({'message': '완료 기록 중 오류가 발생했습니다'}), 500
+
+
+@bp.route('/skip', methods=['POST'])
+def skip_today():
+    user_id = get_user_id_from_session_or_cookies()
+    if not user_id:
+        return jsonify({'message': '로그인이 필요합니다'}), 401
+
+    pref = UserPreferences.query.filter_by(user_id=user_id).first()
+    today = _today_for_user(pref)
+    assignment = (
+        DailyAssignments.query.filter_by(user_id=user_id, assignment_date=today).first()
+    )
+    if assignment is None:
+        return jsonify({'message': '오늘의 배정 WOD가 없습니다'}), 404
+    try:
+        assignment.skipped_at = datetime.utcnow()
+        feedback = assignment.feedback_dict()
+        feedback['user_feedback'] = 'skip'
+        assignment.set_feedback(feedback)
+        db.session.commit()
+        return jsonify({
+            'message': '오늘은 건너뛰셨습니다. 내일 다시 시도해주세요.',
+            'assignment': _serialize_assignment(assignment),
+        }), 200
+    except Exception as e:
+        db.session.rollback()
+        current_app.logger.exception('skip_today error: %s', e)
+        return jsonify({'message': '건너뛰기 처리 중 오류가 발생했습니다'}), 500
+
+
+@bp.route('/feedback', methods=['POST'])
+def feedback_today():
+    """easy / hard / skip 등 사용자 피드백 저장."""
+    user_id = get_user_id_from_session_or_cookies()
+    if not user_id:
+        return jsonify({'message': '로그인이 필요합니다'}), 401
+    body = request.get_json(silent=True) or {}
+    rating = (body.get('rating') or '').strip().lower()
+    if rating not in {'easy', 'moderate', 'hard'}:
+        return jsonify({'message': "rating은 'easy' | 'moderate' | 'hard' 중 하나여야 합니다"}), 400
+
+    pref = UserPreferences.query.filter_by(user_id=user_id).first()
+    today = _today_for_user(pref)
+    assignment = (
+        DailyAssignments.query.filter_by(user_id=user_id, assignment_date=today).first()
+    )
+    if assignment is None:
+        return jsonify({'message': '오늘의 배정 WOD가 없습니다'}), 404
+    try:
+        feedback = assignment.feedback_dict()
+        feedback['user_feedback'] = rating
+        assignment.set_feedback(feedback)
+        db.session.commit()
+        return jsonify({'message': '피드백이 저장되었습니다', 'assignment': _serialize_assignment(assignment)}), 200
+    except Exception as e:
+        db.session.rollback()
+        current_app.logger.exception('feedback_today error: %s', e)
+        return jsonify({'message': '피드백 저장 중 오류가 발생했습니다'}), 500

--- a/backend/utils/push_dispatch.py
+++ b/backend/utils/push_dispatch.py
@@ -1,0 +1,256 @@
+"""APNs(HTTP/2) + FCM(HTTP v1) 디스패처.
+
+이 모듈은 자격증명이 없으면 **WARN 로그 후 no-op**으로 동작한다(앱 크래시 금지).
+실제 발송 코드는 외부 라이브러리 의존을 최소화하기 위해 표준 ``requests``만 사용한다.
+
+필요 환경변수:
+
+APNs:
+- ``APNS_KEY_P8`` (PKCS#8 .p8 파일 본문 또는 base64). 비어 있으면 비활성.
+- ``APNS_KEY_ID`` (10-char Key ID)
+- ``APNS_TEAM_ID`` (10-char Team ID)
+- ``APNS_BUNDLE_ID`` (e.g. com.wodybody.app)
+- ``APNS_USE_SANDBOX`` ("true"면 api.sandbox.push.apple.com)
+
+FCM v1:
+- ``FCM_SERVICE_ACCOUNT_JSON`` (서비스 계정 JSON 본문)
+- ``FCM_PROJECT_ID``
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import time
+from typing import Any, Iterable
+
+import requests
+
+
+logger = logging.getLogger(__name__)
+
+
+# --------------------------------------------------------------------
+# 공용 페이로드 빌더
+# --------------------------------------------------------------------
+
+
+def build_payload(title: str, body: str, *, deeplink: str | None = None,
+                  data_extra: dict[str, Any] | None = None) -> dict[str, Any]:
+    data = dict(data_extra or {})
+    if deeplink:
+        data['deeplink'] = deeplink
+    return {
+        'title': title,
+        'body': body,
+        'data': data,
+    }
+
+
+# --------------------------------------------------------------------
+# APNs (HTTP/2)
+# --------------------------------------------------------------------
+
+
+def _apns_jwt() -> str | None:
+    """APNs용 JWT를 생성. PyJWT 미설치 시 None 반환."""
+    try:
+        import jwt  # type: ignore
+    except Exception:
+        logger.warning('PyJWT 미설치 — APNs JWT 생성 불가. requirements.txt에 PyJWT 추가 필요.')
+        return None
+
+    p8_raw = os.environ.get('APNS_KEY_P8') or ''
+    key_id = os.environ.get('APNS_KEY_ID') or ''
+    team_id = os.environ.get('APNS_TEAM_ID') or ''
+    if not (p8_raw and key_id and team_id):
+        return None
+
+    # 본문 또는 base64 인지 휴리스틱 처리
+    if 'BEGIN PRIVATE KEY' not in p8_raw:
+        try:
+            p8_raw = base64.b64decode(p8_raw).decode('utf-8')
+        except Exception:
+            logger.warning('APNS_KEY_P8 디코드 실패')
+            return None
+
+    now = int(time.time())
+    payload = {'iss': team_id, 'iat': now}
+    headers = {'alg': 'ES256', 'kid': key_id}
+    try:
+        return jwt.encode(payload, p8_raw, algorithm='ES256', headers=headers)
+    except Exception as e:
+        logger.warning('APNs JWT 인코딩 실패: %s', e)
+        return None
+
+
+def _apns_send(token: str, payload: dict[str, Any]) -> tuple[bool, str]:
+    bundle_id = os.environ.get('APNS_BUNDLE_ID') or ''
+    if not bundle_id:
+        return False, 'APNS_BUNDLE_ID not set'
+
+    jwt_token = _apns_jwt()
+    if jwt_token is None:
+        return False, 'apns credentials missing'
+
+    sandbox = (os.environ.get('APNS_USE_SANDBOX') or 'false').lower() == 'true'
+    host = 'api.sandbox.push.apple.com' if sandbox else 'api.push.apple.com'
+    url = f'https://{host}/3/device/{token}'
+
+    aps_payload = {
+        'aps': {
+            'alert': {
+                'title': payload.get('title') or '',
+                'body': payload.get('body') or '',
+            },
+            'sound': 'default',
+            'badge': 1,
+        },
+        'wodybody': payload.get('data') or {},
+    }
+    headers = {
+        'authorization': f'bearer {jwt_token}',
+        'apns-topic': bundle_id,
+        'apns-push-type': 'alert',
+        'content-type': 'application/json',
+    }
+    try:
+        # NOTE: requests는 HTTP/1.1만 지원 — APNs는 HTTP/2가 표준이지만 일부 게이트웨이가 1.1도 허용.
+        # 운영에서는 hyper / httpx[h2]로 교체 권장. 여기선 의존성 최소화를 위해 requests로 시도.
+        resp = requests.post(url, headers=headers, data=json.dumps(aps_payload), timeout=10)
+        if resp.status_code == 200:
+            return True, 'ok'
+        return False, f'apns status={resp.status_code} body={resp.text[:200]}'
+    except requests.RequestException as e:
+        return False, f'apns request failed: {e}'
+
+
+# --------------------------------------------------------------------
+# FCM v1
+# --------------------------------------------------------------------
+
+
+def _fcm_access_token() -> tuple[str | None, str | None]:
+    """서비스 계정 JSON으로 OAuth2 토큰 획득. (token, project_id)."""
+    sa_json = os.environ.get('FCM_SERVICE_ACCOUNT_JSON') or ''
+    if not sa_json:
+        return None, None
+    try:
+        data = json.loads(sa_json)
+    except Exception:
+        try:
+            data = json.loads(base64.b64decode(sa_json).decode('utf-8'))
+        except Exception:
+            logger.warning('FCM_SERVICE_ACCOUNT_JSON 파싱 실패')
+            return None, None
+
+    project_id = data.get('project_id') or os.environ.get('FCM_PROJECT_ID')
+    if not project_id:
+        return None, None
+
+    try:
+        # google-auth가 있을 때만 사용. 없으면 비활성.
+        from google.oauth2 import service_account  # type: ignore
+        from google.auth.transport.requests import Request  # type: ignore
+    except Exception:
+        logger.warning('google-auth 미설치 — FCM 발송 불가. requirements.txt에 google-auth 추가 필요.')
+        return None, project_id
+
+    try:
+        creds = service_account.Credentials.from_service_account_info(
+            data, scopes=['https://www.googleapis.com/auth/firebase.messaging']
+        )
+        creds.refresh(Request())
+        return creds.token, project_id
+    except Exception as e:
+        logger.warning('FCM 액세스 토큰 획득 실패: %s', e)
+        return None, project_id
+
+
+def _fcm_send(token: str, payload: dict[str, Any]) -> tuple[bool, str]:
+    access_token, project_id = _fcm_access_token()
+    if not access_token or not project_id:
+        return False, 'fcm credentials missing'
+
+    url = f'https://fcm.googleapis.com/v1/projects/{project_id}/messages:send'
+    msg = {
+        'message': {
+            'token': token,
+            'notification': {
+                'title': payload.get('title') or '',
+                'body': payload.get('body') or '',
+            },
+            'data': {k: str(v) for k, v in (payload.get('data') or {}).items()},
+        }
+    }
+    headers = {
+        'Authorization': f'Bearer {access_token}',
+        'Content-Type': 'application/json; UTF-8',
+    }
+    try:
+        resp = requests.post(url, headers=headers, data=json.dumps(msg), timeout=10)
+        if resp.status_code == 200:
+            return True, 'ok'
+        return False, f'fcm status={resp.status_code} body={resp.text[:200]}'
+    except requests.RequestException as e:
+        return False, f'fcm request failed: {e}'
+
+
+# --------------------------------------------------------------------
+# 디스패치
+# --------------------------------------------------------------------
+
+
+def is_configured() -> dict[str, bool]:
+    return {
+        'apns': bool(
+            os.environ.get('APNS_KEY_P8')
+            and os.environ.get('APNS_KEY_ID')
+            and os.environ.get('APNS_TEAM_ID')
+            and os.environ.get('APNS_BUNDLE_ID')
+        ),
+        'fcm': bool(os.environ.get('FCM_SERVICE_ACCOUNT_JSON')),
+    }
+
+
+def send_to_tokens(tokens: Iterable[Any], title: str, body: str,
+                   *, deeplink: str | None = None,
+                   data_extra: dict[str, Any] | None = None) -> dict[str, int]:
+    """tokens: list[PushTokens] | list[dict{platform, token}]. 자격증명이 없으면 no-op + WARN."""
+    payload = build_payload(title, body, deeplink=deeplink, data_extra=data_extra)
+    config = is_configured()
+
+    counts = {'ios_sent': 0, 'ios_failed': 0, 'android_sent': 0, 'android_failed': 0, 'skipped': 0}
+    for t in tokens:
+        platform = getattr(t, 'platform', None) or (t.get('platform') if isinstance(t, dict) else None)
+        token = getattr(t, 'token', None) or (t.get('token') if isinstance(t, dict) else None)
+        if not platform or not token:
+            counts['skipped'] += 1
+            continue
+
+        platform = platform.lower()
+        if platform == 'ios':
+            if not config['apns']:
+                counts['skipped'] += 1
+                continue
+            ok, msg = _apns_send(token, payload)
+            if ok:
+                counts['ios_sent'] += 1
+            else:
+                counts['ios_failed'] += 1
+                logger.warning('APNs send failed: %s', msg)
+        elif platform == 'android':
+            if not config['fcm']:
+                counts['skipped'] += 1
+                continue
+            ok, msg = _fcm_send(token, payload)
+            if ok:
+                counts['android_sent'] += 1
+            else:
+                counts['android_failed'] += 1
+                logger.warning('FCM send failed: %s', msg)
+        else:
+            counts['skipped'] += 1
+    return counts

--- a/backend/utils/scheduler.py
+++ b/backend/utils/scheduler.py
@@ -1,0 +1,159 @@
+"""APScheduler 인-프로세스 데일리 푸시 워커.
+
+10분마다 깨어나 ``user_preferences.push_time`` (사용자 timezone 기준)이 현재 분(±10분)
+구간에 들어오는 사용자에게 오늘의 추천을 생성하고 푸시를 발송한다.
+
+APScheduler가 미설치이거나 ``PT_PUSH_WORKER_ENABLED=false``면 워커는 시작되지 않는다.
+APNs/FCM 자격증명이 없는 경우 ``push_dispatch``가 no-op으로 동작하므로 안전하다.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import datetime, timedelta
+
+from config.database import db
+
+
+logger = logging.getLogger(__name__)
+
+
+def _within_window(now_dt: datetime, hhmm: str, window_minutes: int = 10) -> bool:
+    try:
+        hh, mm = hhmm.split(':')
+        target = now_dt.replace(hour=int(hh), minute=int(mm), second=0, microsecond=0)
+    except Exception:
+        return False
+    delta = abs((now_dt - target).total_seconds())
+    return delta <= window_minutes * 60
+
+
+def daily_push_tick(app):
+    """현재 분(±10분) 구간 사용자에게 추천 생성 + 푸시 발송."""
+    from models.preference import UserPreferences
+    from models.push_token import PushTokens
+    from models.daily_assignment import DailyAssignments
+    from models.program import Programs
+    from routes.recommendations import generate_recommendation, _today_for_user
+    from utils.push_dispatch import send_to_tokens, is_configured
+
+    push_disable = (os.environ.get('PT_PUSH_ENABLED') or 'true').lower() == 'false'
+    if push_disable:
+        return
+
+    with app.app_context():
+        try:
+            try:
+                import pytz  # type: ignore
+            except Exception:
+                pytz = None  # type: ignore
+
+            prefs = UserPreferences.query.filter_by(push_enabled=True).all()
+            sent_users = 0
+            for pref in prefs:
+                tz_name = pref.timezone or 'Asia/Seoul'
+                try:
+                    tz = pytz.timezone(tz_name) if pytz else None
+                except Exception:
+                    tz = None
+                now = datetime.now(tz) if tz else datetime.utcnow()
+                push_time = pref.push_time or '09:00'
+                if not _within_window(now, push_time):
+                    continue
+
+                # 오늘 이미 발송했는지 확인 (alert_sent flag in feedback_json)
+                today = _today_for_user(pref)
+                existing = DailyAssignments.query.filter_by(
+                    user_id=pref.user_id, assignment_date=today
+                ).first()
+                if existing is not None:
+                    fb = existing.feedback_dict()
+                    if fb.get('push_sent_at'):
+                        continue
+
+                try:
+                    assignment = generate_recommendation(pref.user_id, today=today)
+                except Exception as e:
+                    logger.warning('generate_recommendation failed user=%s err=%s', pref.user_id, e)
+                    continue
+
+                title = '오늘의 WOD가 도착했어요'
+                body = '오늘은 어떤 운동을 할지 확인해 보세요.'
+                if assignment.program_id:
+                    program = Programs.query.get(assignment.program_id)
+                    if program is not None:
+                        body = f'{program.title} · {assignment.duration_estimate_minutes or pref.available_minutes or 20}분'
+
+                tokens = PushTokens.query.filter_by(user_id=pref.user_id, is_active=True).all()
+                if not tokens:
+                    # 토큰이 없으면 발송 시도 자체를 생략
+                    fb = assignment.feedback_dict()
+                    fb['push_sent_at'] = now.isoformat()
+                    fb['push_skipped_reason'] = 'no_tokens'
+                    assignment.set_feedback(fb)
+                    db.session.commit()
+                    continue
+
+                config = is_configured()
+                if not (config['apns'] or config['fcm']):
+                    fb = assignment.feedback_dict()
+                    fb['push_sent_at'] = now.isoformat()
+                    fb['push_skipped_reason'] = 'creds_missing'
+                    assignment.set_feedback(fb)
+                    db.session.commit()
+                    logger.info('push creds missing — assignment marked but no actual send (user=%s)', pref.user_id)
+                    continue
+
+                counts = send_to_tokens(
+                    tokens, title, body,
+                    deeplink='wodybody://today',
+                    data_extra={
+                        'type': 'daily_recommendation',
+                        'assignment_id': str(assignment.id),
+                        'program_id': str(assignment.program_id or ''),
+                    },
+                )
+                fb = assignment.feedback_dict()
+                fb['push_sent_at'] = now.isoformat()
+                fb['push_counts'] = counts
+                assignment.set_feedback(fb)
+                db.session.commit()
+                sent_users += 1
+            if sent_users:
+                logger.info('daily_push_tick: %s users notified', sent_users)
+        except Exception as e:
+            logger.exception('daily_push_tick error: %s', e)
+
+
+_scheduler = None
+
+
+def start_scheduler(app):
+    """app.py에서 1회 호출. 이미 시작되어 있거나 의존성/플래그가 비활성이면 no-op."""
+    global _scheduler
+    if (os.environ.get('PT_PUSH_WORKER_ENABLED') or 'true').lower() == 'false':
+        app.logger.info('PT push worker disabled (PT_PUSH_WORKER_ENABLED=false)')
+        return None
+    if _scheduler is not None:
+        return _scheduler
+    try:
+        from apscheduler.schedulers.background import BackgroundScheduler
+    except Exception as e:
+        app.logger.warning('APScheduler 미설치 — 일일 푸시 워커 비활성. %s', e)
+        return None
+
+    scheduler = BackgroundScheduler(daemon=True, timezone='UTC')
+    scheduler.add_job(
+        daily_push_tick,
+        trigger='interval',
+        minutes=10,
+        kwargs={'app': app},
+        id='wodybody_daily_push',
+        replace_existing=True,
+        next_run_time=datetime.utcnow() + timedelta(seconds=30),
+    )
+    scheduler.start()
+    _scheduler = scheduler
+    app.logger.info('APScheduler started: wodybody_daily_push every 10min')
+    return scheduler


### PR DESCRIPTION
## 포함\n- `user_preferences`, `daily_assignments`, `push_tokens` 모델 및 마이그레이션 스크립트(`add_pt_tables.*`).\n- 라우트: `/api/me/preferences`, `/api/today`*, 추천, 푸시 토큰 등록.\n- 마켓플레이스 API는 `MARKETPLACE_ENABLED` 플래그 하에 HTTP 410.\n- APScheduler 워커·푸시 디스패치 유틸(자격증명 없으면 스킵).\n## 병합 순서 제안\n- 문서(#4 등) 검토 후, 프론트 PR 전에 또는 동시 배포 필요.\n## 주의\n- DB 마이그레이션은 Railway 등에서 따로 실행.

Made with [Cursor](https://cursor.com)