### PR TITLE
feat(burnfat): Sprint 1 — UX 빠른 승

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ crossfit-system/
 | Sprint | 주제 | 상태 |
 |--------|------|------|
 | **0** | 보안 응급 처치 (PIN 해시 / UPDATE 잠금 / 이미지 signed URL / 디버그 플래그) | ✅ **완료** — commit `64315d3`, 프로덕션 배포·DB 적용·검증 완료. 상세: [`burnfat/docs/SPRINT0_HANDOFF.md`](burnfat/docs/SPRINT0_HANDOFF.md) |
-| **1** | UX 빠른 승 (개인 상태 카드 / D-Day / 랭킹 공유 이미지 / a11y 1차 패스) | ⏳ 미착수 |
+| **1** | UX 빠른 승 (개인 상태 카드 / D-Day / 랭킹 공유 이미지 / a11y 1차 패스) | ✅ **완료** — `MyStatusCard`+`useParticipantIdentity` / `DDayChip`+`EndingSoonDialog` / `RankingShareDialog`(html-to-image) / a11y(aria-label·role=img·메달 텍스트·라인 점선) / 백필 토스트 + vitest 29/29. 상세: [`burnfat/docs/SPRINT1_HANDOFF.md`](burnfat/docs/SPRINT1_HANDOFF.md) |
 | **1.5** | 주간 기록 입력 UX 정상화 (다음 차주 CTA / placeholder / `useNextRecordableWeek`) | ✅ **완료** — `useNextRecordableWeek` hook + 영구 CTA + 미입력 주차 placeholder + WeeklyLogForm 충돌 차단 + 누적 입력률 막대 + vitest 12/12. 상세: [`burnfat/docs/SPRINT1_5_HANDOFF.md`](burnfat/docs/SPRINT1_5_HANDOFF.md) |
 | **2** | AI 조언 서버 캐시 + JSON 응답 / 목표 진행률 / 챌린지 템플릿 | ⏳ 미착수 |
 | **2.5** | 대화형 코치 모달 + 세션·장기 메모리 영속화 | ⏳ 미착수 |

--- a/burnfat/docs/IMPROVEMENT_REPORT_2026-05.md
+++ b/burnfat/docs/IMPROVEMENT_REPORT_2026-05.md
@@ -219,7 +219,7 @@ HomePage(코드 입력) → ChallengePage(/c/:code)
    - 버킷 Private 화, signed URL 7일 유효, 클라이언트에서 매번 갱신.
 4. **디버그 플래그 환경 변수화** (0.5일).
 
-### Sprint 1 — 2~3주차 (UX 임팩트 큰 빠른 승)
+### Sprint 1 — 2~3주차 (UX 임팩트 큰 빠른 승) ✅ **완료 (2026-05-15, [`SPRINT1_HANDOFF.md`](SPRINT1_HANDOFF.md))**
 
 1. **개인 상태 카드** (1일)
    - 닉네임 등록 시 `device_token` 생성 → localStorage 저장 → 재방문 시 자동 식별.

--- a/burnfat/docs/SPRINT1_HANDOFF.md
+++ b/burnfat/docs/SPRINT1_HANDOFF.md
@@ -1,0 +1,104 @@
+# Sprint 1 핸드오프 — UX 빠른 승
+
+> **상태**: ✅ 완료
+> **날짜**: 2026-05-15
+> **선행 Sprint**: [`SPRINT1_5_HANDOFF.md`](SPRINT1_5_HANDOFF.md), [`SPRINT0_HANDOFF.md`](SPRINT0_HANDOFF.md)
+> **로드맵**: [`IMPROVEMENT_REPORT_2026-05.md`](IMPROVEMENT_REPORT_2026-05.md) §6 Sprint 1
+
+---
+
+## 1. 목표
+
+재방문 사용자의 *다음 행동 유도*와 *공유 루프*를 강화한다. 4개 빠른 승 + 백필 토스트.
+모두 **순수 클라이언트 변경** — DB 마이그레이션·RLS·Storage·백엔드 무변경.
+
+---
+
+## 2. 적용된 변경
+
+### 2.1 개인 상태 카드 + 내 참가자 식별
+
+- **신규** [`src/lib/participantIdentity.ts`](../src/lib/participantIdentity.ts) — 챌린지당 1명을 localStorage(`burnfat:identity:<challengeId>`) 에 매핑. *인증이 아니라 UX 식별* 임을 주석에 명시 (쓰기 잠금은 Sprint 0 device_secret 담당).
+- **신규** [`src/hooks/useParticipantIdentity.ts`](../src/hooks/useParticipantIdentity.ts) — localStorage 매핑을 *실제 참가자 목록과 대조* 해 삭제·불일치 id 를 자동 무시. `{ myParticipant, remember, forget }` 반환.
+- **신규** [`src/components/MyStatusCard.tsx`](../src/components/MyStatusCard.tsx) — Tab 0 상단 개인 상태 카드. 시작 인증 / 종료 인증 / 이번 주 기록을 *아이콘 + "완료/미완료" 텍스트 병행* 으로 표시(색상 단독 금지). 미완료 항목에 인라인 액션 버튼. "내가 아니에요" 로 식별 해제.
+- `ChallengePage`: 조인 성공 시 `rememberMe(participantId)`. Tab 0 은 식별 시 `MyStatusCard` + "다른 참가자 추가" 토글, 미식별 시 기존 참가 폼.
+
+### 2.2 D-Day & 종료 임박 알림
+
+- **신규** [`src/lib/challengeSchedule.ts`](../src/lib/challengeSchedule.ts) — 순수 함수. `getChallengePhase` / `getDaysUntilEnd` / `getDaysUntilStart` / `getDDayDisplay`. `getDDayDisplay` 는 칩·모달이 공유하는 단일 표시 모델(`label` / `ariaLabel` / `tone` / `endingSoon`).
+- **신규** [`src/components/DDayChip.tsx`](../src/components/DDayChip.tsx) — 헤더 우측 칩. 색상 + 아이콘 + `aria-label` 병행.
+- **신규** [`src/components/EndingSoonDialog.tsx`](../src/components/EndingSoonDialog.tsx) — 종료 24h 이내 진입 시 챌린지당 1회 모달. `shouldShowEndingSoonNotice` / `dismissEndingSoonNotice` (localStorage `burnfat:endingSoonNotice:<challengeId>`). 식별된 사용자가 종료 인증 미완료면 "지금 종료 인증하기" CTA 분기.
+- `ChallengePage`: 헤더에 `DDayChip`, 진입 시 종료 임박 모달 트리거 effect.
+
+### 2.3 랭킹 공유 이미지
+
+- **신규** 의존성 `html-to-image@^1.11.13`.
+- **신규** [`src/lib/prizeDistribution.ts`](../src/lib/prizeDistribution.ts) — 순수 함수. `computePrizeDistribution(stake, count)` → 상금 풀 + 1등 순이익 + 그 외 순손실. 기본 규칙은 *승자독식* 이며 공유 카드에 "예상" 임을 캡션으로 명시. `formatKrw` 원화 표기.
+- **신규** [`src/components/RankingShareDialog.tsx`](../src/components/RankingShareDialog.tsx) — Top 3 + 예상 정산을 담은 공유 카드. "이미지 저장"(`toPng` → Web Share API 우선, 미지원 시 다운로드) + "텍스트 복사". 기존 텍스트 전용 `handleShareRanking` 을 이 다이얼로그로 일원화.
+
+### 2.4 a11y 1차 패스
+
+- `ChallengePage` 모든 `IconButton`(3개) 에 `aria-label` 추가.
+- 랭킹 메달 셀에 `role="img"` + `aria-label="N위"` — 메달 이모지가 스크린리더에 순위로 읽힘.
+- [`AllParticipantsChart`](../src/components/AllParticipantsChart.tsx) / [`WeeklyLogChart`](../src/components/WeeklyLogChart.tsx) 컨테이너에 `role="img"` + 요약 alt-text.
+- `AllParticipantsChart` 라인에 `CHART_LINE_DASHES` 점선/실선 스타일 매핑 — 색약·흑백 인쇄에서도 라인 구분.
+
+### 2.5 백필 권고 토스트
+
+- **신규** [`src/lib/oneTimeNotice.ts`](../src/lib/oneTimeNotice.ts) — 일회성 안내 가드. `hasSeenNotice` / `markNoticeSeen` (localStorage `burnfat:notice:<key>`). 접근 실패 시 `hasSeenNotice` 가 `true` 를 반환해 *반복 노출(스팸) 을 보수적으로 차단*.
+- `ChallengePage`: 식별된 내 미입력 주차가 2개 이상이면 챌린지당 1회 토스트. `logsLoading` 가드로 *로그 로딩 전 빈 배열을 미입력으로 오인하는* 버그 방지.
+- Sprint 1.5 핸드오프 §4.1 에서 보류했던 항목 — 본 Sprint 의 "내 참가자 식별" 로 활성화.
+
+---
+
+## 3. DoD / 검증
+
+### 3.1 자동 검증
+
+- `npx tsc --noEmit` — 클린.
+- `npm run build` — 성공 (번들 1,107 kB, html-to-image 로 약 +26 kB. 청크 분할은 Sprint 3).
+- `npm test` — **29/29 통과** (challengeSchedule 11 + prizeDistribution 6 + useNextRecordableWeek 12).
+
+### 3.2 빠른 검증 시나리오 (배포 후)
+
+운영 `burnfat.wodybody.com` 에서:
+
+- **S1 개인 상태 카드**: 닉네임으로 참가 → 새로고침 → Tab 0 상단에 "OOO님으로 참여 중" 카드. 시작/종료/이번 주 상태가 아이콘+텍스트로. "내가 아니에요" → 참가 폼 복귀.
+- **S2 D-Day 칩**: 헤더 우측 칩 — 종료 3일 이내 warning, 종료 후 "종료". VoiceOver 로 "종료까지 N일 남음" 읽힘.
+- **S3 종료 임박 모달**: 종료 1일 이내 챌린지 진입 시 1회 모달. 닫으면 재노출 안 됨.
+- **S4 랭킹 공유**: 순위 탭 "결과 공유" → 다이얼로그. "이미지 저장" → PNG 공유/다운로드, "텍스트 복사" → 클립보드. 예상 정산 노출.
+- **S5 a11y**: 메달 셀이 "1위"로 읽힘. 전체 추이 차트 라인이 점선/실선으로도 구분.
+- **S6 백필 토스트**: 내 미입력 주차 2개 이상인 챌린지 진입 시 1회 토스트.
+
+---
+
+## 4. 알려진 잔여 위험 / 후속 처리
+
+- **식별의 한계**: localStorage 기반이라 *기기 변경·시크릿 모드·localStorage 삭제* 시 식별이 풀린다. 의도된 한계 — 재식별은 "다른 참가자 추가" 후 같은 닉네임 재등록이 아니라, 향후 Supabase Auth(분기 백로그) 도입 시 정식 해결. 현재는 닉네임 unique 제약 때문에 같은 닉으로 재참가가 불가하므로, 식별이 풀리면 개인 상태 카드를 다시 못 볼 수 있음. → Sprint 2+ 에서 "기존 참가자 중에서 나 선택" UI 검토 권장.
+- **html-to-image 폰트/이모지**: 메달 이모지는 시스템 폰트에 의존. 일부 구형 기기에서 PNG 의 이모지 렌더가 텍스트와 다를 수 있음. 텍스트 복사 폴백 제공.
+- **승자독식 가정**: `prizeDistribution` 은 규칙을 가정한다. 제품이 분배 규칙을 확정하면 `PRIZE_RULE_LABEL` + `computePrizeDistribution` 만 교체.
+- **rank-1 행 데코 애니메이션**: `prefers-reduced-motion` 이 스켈레톤·데코 애니메이션 일부에만 적용됨(IMPROVEMENT_REPORT §2.3). 랭킹 1등 행 shimmer/glow 는 미적용 — Sprint 3 `ChallengePage` 분해 시 함께 처리 권장.
+- **테스트 커버리지**: 순수 lib 함수만 vitest 검증. 컴포넌트·hook(localStorage·DOM) 은 Sprint 3 의 jsdom + testing-library 도입 시 커버.
+
+---
+
+## 5. 다음 단계
+
+1. **Sprint 2 — AI 조언 서버 캐시 + JSON 응답 / 목표 진행률 / 챌린지 템플릿**. 진입: `backend/routes/burnfat_ai.py`, `hooks/useAIAdvice.ts`, 신규 테이블 `weekly_ai_advice`.
+2. **Sprint 2.5 — 대화형 코치 모달**. 신규 마이그레이션 `coach_sessions` / `coach_messages` / `participant_coach_memory`.
+3. **Sprint 3 — ChallengePage 분해 / N+1 제거 / 테스트 베이스라인**. `ChallengePage` 는 본 Sprint 로 ~1,250줄 — 분해 우선순위가 더 올라감.
+
+각 Sprint DoD 는 `IMPROVEMENT_REPORT_2026-05.md` 해당 섹션 기준.
+
+---
+
+## 6. 빠른 롤백 가이드
+
+Sprint 1 은 **순수 클라이언트 변경** (DB·RLS·Storage·백엔드·환경변수 무변경). 데이터 회수 불요.
+
+1. **Vercel 단독 롤백 (권장, 60초)**: Deployments → Sprint 1 직전 빌드(Sprint 1.5 커밋 `e20cbe9`) *Promote to Production*.
+2. **소스 revert**: `git revert <Sprint 1 머지 커밋>` 후 푸시 → Vercel 자동 재배포.
+3. **부분 비활성**: 특정 기능만 끄려면 `ChallengePage` 에서 해당 컴포넌트 렌더 줄만 주석 처리 (`<DDayChip>` / `<MyStatusCard>` / `<EndingSoonDialog>` / `<RankingShareDialog>`). 신규 컴포넌트로 분리돼 있어 격리 제거가 쉬움.
+4. **localStorage 잔류**: `burnfat:identity:*` / `burnfat:notice:*` / `burnfat:endingSoonNotice:*` 키는 롤백해도 남지만 무해 (다음 코드가 무시).
+
+— 끝 —

--- a/burnfat/package-lock.json
+++ b/burnfat/package-lock.json
@@ -13,6 +13,7 @@
         "@mui/icons-material": "^7.3.2",
         "@mui/material": "^7.3.2",
         "@supabase/supabase-js": "^2.47.10",
+        "html-to-image": "^1.11.13",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.28.0",
@@ -2535,6 +2536,12 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
+    "node_modules/html-to-image": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
+      "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
       "license": "MIT"
     },
     "node_modules/iceberg-js": {

--- a/burnfat/package.json
+++ b/burnfat/package.json
@@ -16,6 +16,7 @@
     "@mui/icons-material": "^7.3.2",
     "@mui/material": "^7.3.2",
     "@supabase/supabase-js": "^2.47.10",
+    "html-to-image": "^1.11.13",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.28.0",

--- a/burnfat/src/components/AllParticipantsChart.tsx
+++ b/burnfat/src/components/AllParticipantsChart.tsx
@@ -24,6 +24,19 @@ export const CHART_COLORS = [
   '#ca8a04',
 ];
 
+// Sprint 1 a11y: 색약/흑백 인쇄 사용자를 위해 라인을 색상만이 아니라
+// 점선/실선 스타일로도 구분한다. CHART_COLORS 와 같은 길이로 순환.
+export const CHART_LINE_DASHES = [
+  '0',        // 실선
+  '6 3',      // 긴 점선
+  '2 3',      // 짧은 점선
+  '8 3 2 3',  // 일점쇄선
+  '1 4',      // 도트
+  '10 4',     // 더 긴 점선
+  '4 2 1 2',  // 촘촘한 쇄선
+  '12 3 3 3', // 긴 쇄선
+];
+
 interface Props {
   participants: ParticipantWithSubmissions[];
   logsByParticipant: Record<string, WeeklyLog[]>;
@@ -62,8 +75,11 @@ export default function AllParticipantsChart({ participants, logsByParticipant }
     );
   }
 
+  // a11y: 차트를 보지 못하는 사용자를 위한 요약 대체 텍스트.
+  const chartAlt = `${participants.length}명 참가자의 주차별 체지방률 추이 꺾은선 그래프. ${weekList.length}개 주차 기록.`;
+
   return (
-    <Box sx={{ width: '100%', height: 280 }}>
+    <Box sx={{ width: '100%', height: 280 }} role="img" aria-label={chartAlt}>
       <ResponsiveContainer width="100%" height="100%">
         <LineChart data={data} margin={{ top: 8, right: 8, left: 4, bottom: 0 }}>
           <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
@@ -85,6 +101,7 @@ export default function AllParticipantsChart({ participants, logsByParticipant }
               type="monotone"
               dataKey={p.nickname}
               stroke={CHART_COLORS[idx % CHART_COLORS.length]}
+              strokeDasharray={CHART_LINE_DASHES[idx % CHART_LINE_DASHES.length]}
               strokeWidth={2}
               dot={{ r: 3 }}
               connectNulls

--- a/burnfat/src/components/DDayChip.tsx
+++ b/burnfat/src/components/DDayChip.tsx
@@ -1,0 +1,39 @@
+import Chip from '@mui/material/Chip';
+import EventIcon from '@mui/icons-material/Event';
+import LocalFireDepartmentIcon from '@mui/icons-material/LocalFireDepartment';
+import FlagIcon from '@mui/icons-material/Flag';
+import type { DDayDisplay } from '../lib/challengeSchedule';
+
+interface Props {
+  dday: DDayDisplay;
+}
+
+/**
+ * Sprint 1 — 헤더 D-Day 칩.
+ * 색상은 보조 신호일 뿐이며, 라벨 텍스트 + 아이콘 + aria-label 로 의미를 병행 전달한다.
+ */
+export default function DDayChip({ dday }: Props) {
+  const color: 'default' | 'info' | 'warning' =
+    dday.tone === 'warning' ? 'warning' : dday.tone === 'info' ? 'info' : 'default';
+
+  const icon =
+    dday.tone === 'ended' ? (
+      <FlagIcon />
+    ) : dday.tone === 'warning' ? (
+      <LocalFireDepartmentIcon />
+    ) : (
+      <EventIcon />
+    );
+
+  return (
+    <Chip
+      icon={icon}
+      label={dday.label}
+      color={color}
+      size="small"
+      variant={dday.tone === 'warning' ? 'filled' : 'outlined'}
+      aria-label={dday.ariaLabel}
+      sx={{ fontWeight: 600, height: 28 }}
+    />
+  );
+}

--- a/burnfat/src/components/EndingSoonDialog.tsx
+++ b/burnfat/src/components/EndingSoonDialog.tsx
@@ -1,0 +1,112 @@
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import Button from '@mui/material/Button';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Divider from '@mui/material/Divider';
+import LocalFireDepartmentIcon from '@mui/icons-material/LocalFireDepartment';
+
+const STORAGE_PREFIX = 'burnfat:endingSoonNotice:';
+
+/**
+ * 종료 임박 모달을 이 챌린지에 대해 이미 봤는지. 챌린지당 1회만 노출.
+ */
+export function shouldShowEndingSoonNotice(challengeId: string): boolean {
+  if (!challengeId) return false;
+  try {
+    return localStorage.getItem(`${STORAGE_PREFIX}${challengeId}`) == null;
+  } catch {
+    return false;
+  }
+}
+
+export function dismissEndingSoonNotice(challengeId: string): void {
+  if (!challengeId) return;
+  try {
+    localStorage.setItem(`${STORAGE_PREFIX}${challengeId}`, new Date().toISOString());
+  } catch {
+    // 무시
+  }
+}
+
+interface Props {
+  open: boolean;
+  /** D-Day 라벨 (예: "D-1", "D-DAY"). */
+  ddayLabel: string;
+  endDate: string;
+  /** 내 종료 인증이 아직 미완료인지 — 메시지를 분기. 식별 안 됐으면 undefined. */
+  myEndPending?: boolean;
+  onClose: () => void;
+  /** "지금 종료 인증하기" — 식별된 사용자가 종료 인증 미완료일 때만 노출. */
+  onAuthEnd?: () => void;
+}
+
+/**
+ * Sprint 1 — 종료 임박 알림 모달.
+ * 종료 24h 이내 진입 시 챌린지당 1회 노출해, 종료 인증 마감을 놓치지 않게 한다.
+ */
+export default function EndingSoonDialog({
+  open,
+  ddayLabel,
+  endDate,
+  myEndPending,
+  onClose,
+  onAuthEnd,
+}: Props) {
+  const showAuthCta = myEndPending === true && !!onAuthEnd;
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth PaperProps={{ sx: { borderRadius: 3, mx: 2 } }}>
+      <DialogTitle sx={{ pb: 1.25 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <LocalFireDepartmentIcon sx={{ color: 'warning.main' }} aria-hidden />
+          <Box>
+            <Typography variant="h6" fontWeight={700} lineHeight={1.2}>
+              종료가 임박했어요 · {ddayLabel}
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              종료일 {endDate}
+            </Typography>
+          </Box>
+        </Box>
+      </DialogTitle>
+
+      <Divider />
+
+      <DialogContent sx={{ px: 2.5, py: 2.5 }}>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 1.5 }}>
+          {showAuthCta
+            ? '아직 종료 인증을 마치지 않았어요. 종료일이 지나면 인증과 순위 반영이 어려워집니다. 지금 인증을 마쳐 주세요.'
+            : '챌린지 종료가 다가옵니다. 참가자 전원이 종료 인증을 마치면 최종 순위가 자동 공개됩니다.'}
+        </Typography>
+        <Box sx={{ p: 1.5, borderRadius: 2, bgcolor: 'warning.50', border: '1px solid', borderColor: 'warning.200' }}>
+          <Typography variant="caption" color="text.secondary">
+            놓치기 쉬운 마감 — 친구들에게도 종료 인증을 한 번 알려 주세요.
+          </Typography>
+        </Box>
+      </DialogContent>
+
+      <Divider />
+
+      <DialogActions sx={{ px: 2.5, py: 1.5, justifyContent: showAuthCta ? 'space-between' : 'flex-end' }}>
+        <Button color="inherit" onClick={onClose}>
+          닫기
+        </Button>
+        {showAuthCta && (
+          <Button
+            variant="contained"
+            color="warning"
+            onClick={() => {
+              onClose();
+              onAuthEnd?.();
+            }}
+          >
+            지금 종료 인증하기
+          </Button>
+        )}
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/burnfat/src/components/MyStatusCard.tsx
+++ b/burnfat/src/components/MyStatusCard.tsx
@@ -1,0 +1,156 @@
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Typography from '@mui/material/Typography';
+import Chip from '@mui/material/Chip';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import RadioButtonUncheckedIcon from '@mui/icons-material/RadioButtonUnchecked';
+import PersonIcon from '@mui/icons-material/Person';
+import AddIcon from '@mui/icons-material/Add';
+import type { ParticipantWithSubmissions, WeeklyLog } from '../types';
+import { useNextRecordableWeek } from '../hooks/useNextRecordableWeek';
+
+interface Props {
+  participant: ParticipantWithSubmissions;
+  logs: WeeklyLog[];
+  challengeStartDate: string;
+  challengeEndDate: string;
+  onAuthStart: () => void;
+  onAuthEnd: () => void;
+  onOpenWeeklyLog: (weekNo?: number) => void;
+  /** "내가 아니에요" — 식별 해제. */
+  onForget: () => void;
+}
+
+interface StatusRowProps {
+  label: string;
+  done: boolean;
+  /** 미완료 시 노출할 액션 버튼 라벨. 없으면 버튼 미노출. */
+  actionLabel?: string;
+  onAction?: () => void;
+}
+
+/** 상태 한 줄 — 색상 단독이 아닌 아이콘 + "완료/미완료" 텍스트 병행 (a11y). */
+function StatusRow({ label, done, actionLabel, onAction }: StatusRowProps) {
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, py: 0.5 }}>
+      {done ? (
+        <CheckCircleIcon sx={{ fontSize: 20, color: 'success.main' }} aria-hidden />
+      ) : (
+        <RadioButtonUncheckedIcon sx={{ fontSize: 20, color: 'text.disabled' }} aria-hidden />
+      )}
+      <Typography variant="body2" sx={{ flex: '1 1 auto', minWidth: 0 }}>
+        {label}{' '}
+        <Box
+          component="span"
+          sx={{ fontWeight: 600, color: done ? 'success.main' : 'text.secondary' }}
+        >
+          {done ? '완료' : '미완료'}
+        </Box>
+      </Typography>
+      {!done && actionLabel && onAction && (
+        <Button
+          size="small"
+          variant="outlined"
+          onClick={onAction}
+          sx={{ minHeight: 36, fontSize: '0.75rem', py: 0.25, px: 1.25, flexShrink: 0 }}
+        >
+          {actionLabel}
+        </Button>
+      )}
+    </Box>
+  );
+}
+
+/**
+ * Sprint 1 — 개인 상태 카드.
+ * 이 디바이스에서 식별된 "나" 의 시작/종료 인증·이번 주 기록 상태를 한눈에 보여 주고,
+ * 미완료 항목에 바로 액션 버튼을 노출해 재방문 사용자의 다음 행동을 유도한다.
+ */
+export default function MyStatusCard({
+  participant,
+  logs,
+  challengeStartDate,
+  challengeEndDate,
+  onAuthStart,
+  onAuthEnd,
+  onOpenWeeklyLog,
+  onForget,
+}: Props) {
+  const hasStart = participant.submissions.some((s) => s.type === 'start');
+  const hasEnd = participant.submissions.some((s) => s.type === 'end');
+  const next = useNextRecordableWeek(logs, challengeStartDate, challengeEndDate);
+  // 이번 주 기록 완료 여부 — 'ready' 면 이번 주 미입력, 그 외(caught_up/already_done)는 완료.
+  const thisWeekDone = next.status !== 'ready';
+  const weekLabel =
+    next.status === 'ready' && next.suggestedWeekNo != null
+      ? `${next.suggestedWeekNo}주차 기록 입력`
+      : '주간 기록 입력';
+
+  return (
+    <Card sx={{ mx: 2, mb: 2, border: '1px solid', borderColor: 'primary.200', bgcolor: 'primary.50' }}>
+      <CardContent sx={{ p: 2 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+          <PersonIcon sx={{ fontSize: 20, color: 'primary.main' }} aria-hidden />
+          <Typography variant="subtitle2" color="primary.dark" sx={{ flex: '1 1 auto', minWidth: 0 }}>
+            <Box component="span" fontWeight={700}>
+              {participant.nickname}
+            </Box>
+            님으로 참여 중
+          </Typography>
+          <Chip
+            size="small"
+            label="이 기기에서 식별됨"
+            variant="outlined"
+            sx={{ height: 22, fontSize: '0.6875rem' }}
+          />
+        </Box>
+
+        <Box sx={{ bgcolor: 'background.paper', borderRadius: 1.5, px: 1.5, py: 0.5, mb: 1 }}>
+          <StatusRow
+            label="시작 인증"
+            done={hasStart}
+            actionLabel="시작일 인증"
+            onAction={onAuthStart}
+          />
+          <StatusRow
+            label="종료 인증"
+            done={hasEnd}
+            actionLabel="종료일 인증"
+            onAction={onAuthEnd}
+          />
+          <StatusRow
+            label="이번 주 기록"
+            done={thisWeekDone}
+            actionLabel={weekLabel}
+            onAction={() => onOpenWeeklyLog(next.suggestedWeekNo ?? undefined)}
+          />
+        </Box>
+
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 1 }}>
+          <Button
+            size="small"
+            variant="text"
+            color="inherit"
+            onClick={onForget}
+            sx={{ fontSize: '0.75rem', color: 'text.secondary' }}
+          >
+            내가 아니에요
+          </Button>
+          {!hasStart && (
+            <Button
+              size="small"
+              variant="contained"
+              startIcon={<AddIcon sx={{ fontSize: 16 }} />}
+              onClick={onAuthStart}
+              sx={{ minHeight: 36 }}
+            >
+              지금 시작 인증하기
+            </Button>
+          )}
+        </Box>
+      </CardContent>
+    </Card>
+  );
+}

--- a/burnfat/src/components/RankingShareDialog.tsx
+++ b/burnfat/src/components/RankingShareDialog.tsx
@@ -1,0 +1,230 @@
+import { useRef, useState } from 'react';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import Button from '@mui/material/Button';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import DownloadIcon from '@mui/icons-material/Download';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import { toPng } from 'html-to-image';
+import type { Challenge, RankingRow } from '../types';
+import { computePrizeDistribution, formatKrw, PRIZE_RULE_LABEL } from '../lib/prizeDistribution';
+
+interface Props {
+  open: boolean;
+  challenge: Challenge;
+  ranking: RankingRow[];
+  participantCount: number;
+  shareUrl: string;
+  onClose: () => void;
+  onToast: (message: string) => void;
+}
+
+function medalText(rank: number): string {
+  if (rank === 1) return '🥇';
+  if (rank === 2) return '🥈';
+  if (rank === 3) return '🥉';
+  return `${rank}위`;
+}
+
+/**
+ * Sprint 1 — 랭킹 공유.
+ * 공유용 카드(PNG) + 텍스트 복사. 카드에는 Top 3 + 예상 상금 분배를 포함한다.
+ */
+export default function RankingShareDialog({
+  open,
+  challenge,
+  ranking,
+  participantCount,
+  shareUrl,
+  onClose,
+  onToast,
+}: Props) {
+  const cardRef = useRef<HTMLDivElement>(null);
+  const [exporting, setExporting] = useState(false);
+
+  const prize = computePrizeDistribution(challenge.stake_amount, participantCount);
+  const top3 = ranking.slice(0, 3);
+
+  const buildShareText = (): string => {
+    const lines = [
+      '🔥 BurnFat 대결 결과',
+      `📌 ${challenge.title}`,
+      `📅 ${challenge.start_date} ~ ${challenge.end_date}`,
+      '',
+      ...ranking.map((r) => `${medalText(r.rank)} ${r.nickname}  -${r.reductionRate.toFixed(2)}%`),
+    ];
+    if (prize.hasPrize) {
+      lines.push(
+        '',
+        `💰 예상 정산 (${PRIZE_RULE_LABEL})`,
+        `· 1등 +${formatKrw(prize.winnerNet)} / 그 외 ${formatKrw(prize.loserNet)}`
+      );
+    }
+    lines.push('', `🔗 ${shareUrl}`);
+    return lines.join('\n');
+  };
+
+  const handleCopyText = () => {
+    navigator.clipboard
+      .writeText(buildShareText())
+      .then(() => onToast('결과 텍스트가 클립보드에 복사되었습니다'))
+      .catch(() => onToast('복사에 실패했습니다. 다시 시도해주세요.'));
+  };
+
+  const handleSaveImage = async () => {
+    if (!cardRef.current) return;
+    setExporting(true);
+    try {
+      const dataUrl = await toPng(cardRef.current, {
+        pixelRatio: 2,
+        backgroundColor: '#ffffff',
+        cacheBust: true,
+      });
+      // Web Share API 로 파일 공유가 가능하면 우선 사용 (모바일).
+      const fileName = `burnfat-${challenge.code}.png`;
+      const blob = await (await fetch(dataUrl)).blob();
+      const file = new File([blob], fileName, { type: 'image/png' });
+      const nav = navigator as Navigator & {
+        canShare?: (data: { files: File[] }) => boolean;
+        share?: (data: { files: File[]; title?: string }) => Promise<void>;
+      };
+      if (nav.canShare && nav.share && nav.canShare({ files: [file] })) {
+        await nav.share({ files: [file], title: `${challenge.title} 대결 결과` });
+        onToast('공유 시트를 열었습니다');
+      } else {
+        const link = document.createElement('a');
+        link.download = fileName;
+        link.href = dataUrl;
+        link.click();
+        onToast('결과 이미지를 저장했습니다');
+      }
+    } catch {
+      onToast('이미지 생성에 실패했습니다. 텍스트 복사를 이용해주세요.');
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth PaperProps={{ sx: { borderRadius: 3, mx: 2 } }}>
+      <DialogTitle sx={{ pb: 1 }}>결과 공유</DialogTitle>
+      <DialogContent sx={{ px: 2, py: 1 }}>
+        {/* 캡처 대상 카드 */}
+        <Box
+          ref={cardRef}
+          sx={{
+            bgcolor: '#ffffff',
+            borderRadius: 3,
+            border: '1px solid',
+            borderColor: 'grey.200',
+            p: 2.5,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 1.25,
+          }}
+        >
+          <Box>
+            <Typography variant="subtitle2" sx={{ color: '#ea580c', fontWeight: 700 }}>
+              🔥 BurnFat 대결 결과
+            </Typography>
+            <Typography variant="h6" fontWeight={800} lineHeight={1.25}>
+              {challenge.title}
+            </Typography>
+            <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+              {challenge.start_date} ~ {challenge.end_date}
+            </Typography>
+          </Box>
+
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.75 }}>
+            {top3.map((r) => {
+              const isFirst = r.rank === 1;
+              return (
+                <Box
+                  key={r.nickname}
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 1,
+                    px: 1.25,
+                    py: 1,
+                    borderRadius: 2,
+                    bgcolor: isFirst ? '#fef3c7' : '#f8fafc',
+                    border: '1px solid',
+                    borderColor: isFirst ? '#fcd34d' : '#e2e8f0',
+                  }}
+                >
+                  <Box component="span" sx={{ fontSize: 22, lineHeight: 1, minWidth: 30, textAlign: 'center' }}>
+                    {medalText(r.rank)}
+                  </Box>
+                  <Typography
+                    sx={{
+                      flex: '1 1 auto',
+                      minWidth: 0,
+                      fontWeight: isFirst ? 800 : 600,
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    {r.nickname}
+                  </Typography>
+                  <Typography sx={{ fontWeight: 700, color: isFirst ? '#b45309' : '#16a34a' }}>
+                    -{r.reductionRate.toFixed(2)}%
+                  </Typography>
+                </Box>
+              );
+            })}
+            {ranking.length > 3 && (
+              <Typography variant="caption" sx={{ color: 'text.secondary', textAlign: 'center' }}>
+                외 {ranking.length - 3}명
+              </Typography>
+            )}
+          </Box>
+
+          {prize.hasPrize && (
+            <Box sx={{ bgcolor: '#f0fdf4', borderRadius: 2, p: 1.25, border: '1px solid', borderColor: '#bbf7d0' }}>
+              <Typography variant="caption" sx={{ fontWeight: 700, color: '#15803d', display: 'block' }}>
+                💰 예상 정산 · {PRIZE_RULE_LABEL}
+              </Typography>
+              <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                상금 풀 {formatKrw(prize.pot)} · 1등 +{formatKrw(prize.winnerNet)} · 그 외 {formatKrw(prize.loserNet)}
+              </Typography>
+            </Box>
+          )}
+
+          <Typography variant="caption" sx={{ color: 'text.disabled', textAlign: 'center' }}>
+            대결 코드 {challenge.code} · burnfat.wodybody.com
+          </Typography>
+        </Box>
+
+        <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 1, textAlign: 'center' }}>
+          정산 금액은 승자독식 가정의 예상치입니다. 실제 분배는 대결방에서 합의하세요.
+        </Typography>
+      </DialogContent>
+      <DialogActions sx={{ px: 2, pb: 2, gap: 1, flexWrap: 'wrap' }}>
+        <Button onClick={onClose} color="inherit">
+          닫기
+        </Button>
+        <Box sx={{ flex: 1 }} />
+        <Button
+          variant="outlined"
+          startIcon={<ContentCopyIcon />}
+          onClick={handleCopyText}
+        >
+          텍스트 복사
+        </Button>
+        <Button
+          variant="contained"
+          startIcon={<DownloadIcon />}
+          onClick={handleSaveImage}
+          disabled={exporting}
+        >
+          {exporting ? '생성 중...' : '이미지 저장'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/burnfat/src/components/WeeklyLogChart.tsx
+++ b/burnfat/src/components/WeeklyLogChart.tsx
@@ -78,7 +78,11 @@ export default function WeeklyLogChart({ logs, participant, startBodyFat }: Prop
           />
         </Box>
       )}
-      <Box sx={{ width: '100%', height: 240 }}>
+      <Box
+        sx={{ width: '100%', height: 240 }}
+        role="img"
+        aria-label={`${participant.nickname}님의 주차별 ${isWeight ? '몸무게' : '체지방률'} 추이 꺾은선 그래프`}
+      >
         <ResponsiveContainer width="100%" height="100%">
           <LineChart data={data} margin={{ top: 8, right: 8, left: 4, bottom: 0 }}>
             <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />

--- a/burnfat/src/hooks/useParticipantIdentity.ts
+++ b/burnfat/src/hooks/useParticipantIdentity.ts
@@ -1,0 +1,55 @@
+import { useState, useEffect, useMemo, useCallback } from 'react';
+import type { ParticipantWithSubmissions } from '../types';
+import {
+  getRememberedParticipantId,
+  rememberParticipant,
+  forgetParticipant,
+} from '../lib/participantIdentity';
+
+export interface ParticipantIdentity {
+  /** 이 디바이스에서 식별된 "나" — 현재 참가자 목록에 실제 존재하는 경우에만 non-null. */
+  myParticipant: ParticipantWithSubmissions | null;
+  /** 조인 성공 시 호출해 "나" 로 기억. */
+  remember: (participantId: string) => void;
+  /** "내가 아니에요" — 식별 해제. */
+  forget: () => void;
+}
+
+/**
+ * Sprint 1 — 내 참가자 식별 hook.
+ *
+ * localStorage 의 매핑을 읽되, *실제 참가자 목록과 대조* 해 삭제·불일치된 id 는
+ * 자동으로 무시한다. 이 식별은 인증이 아니라 UX 편의용임에 유의.
+ */
+export function useParticipantIdentity(
+  challengeId: string | undefined,
+  participants: ParticipantWithSubmissions[]
+): ParticipantIdentity {
+  const [myId, setMyId] = useState<string | null>(null);
+
+  useEffect(() => {
+    setMyId(challengeId ? getRememberedParticipantId(challengeId) : null);
+  }, [challengeId]);
+
+  const myParticipant = useMemo(
+    () => (myId ? participants.find((p) => p.id === myId) ?? null : null),
+    [participants, myId]
+  );
+
+  const remember = useCallback(
+    (participantId: string) => {
+      if (!challengeId) return;
+      rememberParticipant(challengeId, participantId);
+      setMyId(participantId);
+    },
+    [challengeId]
+  );
+
+  const forget = useCallback(() => {
+    if (!challengeId) return;
+    forgetParticipant(challengeId);
+    setMyId(null);
+  }, [challengeId]);
+
+  return { myParticipant, remember, forget };
+}

--- a/burnfat/src/lib/challengeSchedule.test.ts
+++ b/burnfat/src/lib/challengeSchedule.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getChallengePhase,
+  getDaysUntilEnd,
+  getDaysUntilStart,
+  getDDayDisplay,
+} from './challengeSchedule';
+
+const START = '2026-05-04';
+const END = '2026-06-01';
+
+describe('getChallengePhase', () => {
+  it('시작 전 / 진행 중 / 종료 후를 구분', () => {
+    expect(getChallengePhase(START, END, new Date('2026-05-01'))).toBe('before');
+    expect(getChallengePhase(START, END, new Date('2026-05-15'))).toBe('active');
+    expect(getChallengePhase(START, END, new Date('2026-06-10'))).toBe('ended');
+  });
+
+  it('시작일·종료일 당일은 active', () => {
+    expect(getChallengePhase(START, END, new Date(START))).toBe('active');
+    expect(getChallengePhase(START, END, new Date(END))).toBe('active');
+  });
+});
+
+describe('getDaysUntilEnd / getDaysUntilStart', () => {
+  it('종료일까지 남은 일수 — 당일 0, 지난 뒤 음수', () => {
+    expect(getDaysUntilEnd(END, new Date('2026-05-29'))).toBe(3);
+    expect(getDaysUntilEnd(END, new Date(END))).toBe(0);
+    expect(getDaysUntilEnd(END, new Date('2026-06-03'))).toBe(-2);
+  });
+
+  it('시작일까지 남은 일수', () => {
+    expect(getDaysUntilStart(START, new Date('2026-05-01'))).toBe(3);
+    expect(getDaysUntilStart(START, new Date(START))).toBe(0);
+  });
+
+  it('빈 날짜는 null', () => {
+    expect(getDaysUntilEnd('', new Date())).toBeNull();
+    expect(getDaysUntilStart('', new Date())).toBeNull();
+  });
+});
+
+describe('getDDayDisplay', () => {
+  it('시작 전 — 시작 D-N, info 톤', () => {
+    const d = getDDayDisplay(START, END, new Date('2026-05-01'));
+    expect(d.label).toBe('시작 D-3');
+    expect(d.tone).toBe('info');
+    expect(d.endingSoon).toBe(false);
+  });
+
+  it('종료 3일 전 — D-3, warning 톤, 모달 미트리거', () => {
+    const d = getDDayDisplay(START, END, new Date('2026-05-29'));
+    expect(d.label).toBe('D-3');
+    expect(d.tone).toBe('warning');
+    expect(d.endingSoon).toBe(false);
+  });
+
+  it('종료 1일 전 — D-1, 종료 임박(모달 트리거)', () => {
+    const d = getDDayDisplay(START, END, new Date('2026-05-31'));
+    expect(d.label).toBe('D-1');
+    expect(d.endingSoon).toBe(true);
+  });
+
+  it('종료 당일 — D-DAY, 종료 임박', () => {
+    const d = getDDayDisplay(START, END, new Date(END));
+    expect(d.label).toBe('D-DAY');
+    expect(d.tone).toBe('warning');
+    expect(d.endingSoon).toBe(true);
+  });
+
+  it('종료 후 — 종료, ended 톤', () => {
+    const d = getDDayDisplay(START, END, new Date('2026-06-10'));
+    expect(d.label).toBe('종료');
+    expect(d.tone).toBe('ended');
+    expect(d.endingSoon).toBe(false);
+  });
+
+  it('여유 있는 진행 중 — D-N, default 톤', () => {
+    const d = getDDayDisplay(START, END, new Date('2026-05-10'));
+    expect(d.tone).toBe('default');
+    expect(d.endingSoon).toBe(false);
+  });
+});

--- a/burnfat/src/lib/challengeSchedule.ts
+++ b/burnfat/src/lib/challengeSchedule.ts
@@ -1,0 +1,112 @@
+/**
+ * Sprint 1 — 챌린지 일정/D-Day 계산.
+ *
+ * 모든 함수는 순수 함수로, 테스트용 `today` 주입을 받는다.
+ * 날짜는 `YYYY-MM-DD` (또는 ISO) 문자열. 비교는 UTC 자정 기준으로 통일한다.
+ */
+
+export type ChallengePhase = 'before' | 'active' | 'ended';
+
+function toDateOnly(value: string): string {
+  return (value || '').split('T')[0].slice(0, 10);
+}
+
+function todayIso(today?: Date): string {
+  return (today ?? new Date()).toISOString().slice(0, 10);
+}
+
+/** 두 날짜(YYYY-MM-DD) 사이의 일수 차 (b - a). */
+function diffDays(a: string, b: string): number {
+  const ms = new Date(b).getTime() - new Date(a).getTime();
+  return Math.round(ms / (1000 * 60 * 60 * 24));
+}
+
+/** 챌린지가 시작 전 / 진행 중 / 종료됨 중 어디인지. */
+export function getChallengePhase(
+  startDate: string,
+  endDate: string,
+  today?: Date
+): ChallengePhase {
+  const t = todayIso(today);
+  const start = toDateOnly(startDate);
+  const end = toDateOnly(endDate);
+  if (start && t < start) return 'before';
+  if (end && t > end) return 'ended';
+  return 'active';
+}
+
+/** 종료일까지 남은 일수. 종료 당일=0, 지난 뒤=음수. end_date 없으면 null. */
+export function getDaysUntilEnd(endDate: string, today?: Date): number | null {
+  const end = toDateOnly(endDate);
+  if (!end) return null;
+  return diffDays(todayIso(today), end);
+}
+
+/** 시작일까지 남은 일수. 시작 당일=0, 지난 뒤=음수. start_date 없으면 null. */
+export function getDaysUntilStart(startDate: string, today?: Date): number | null {
+  const start = toDateOnly(startDate);
+  if (!start) return null;
+  return diffDays(todayIso(today), start);
+}
+
+export interface DDayDisplay {
+  /** 칩에 표시할 짧은 라벨. 예: "D-3", "D-DAY", "종료", "시작 D-2". */
+  label: string;
+  /** 스크린리더용 풀 텍스트. 예: "종료까지 3일 남음". */
+  ariaLabel: string;
+  /** 의미 색상 — 색 단독 정보 금지 원칙에 따라 항상 label/ariaLabel 과 병행. */
+  tone: 'default' | 'info' | 'warning' | 'ended';
+  /** 종료 임박(24h 이내, 진행 중) 여부 — 모달 노출 트리거. */
+  endingSoon: boolean;
+}
+
+/**
+ * 헤더 D-Day 칩 + 종료 임박 모달이 함께 쓰는 단일 표시 모델.
+ */
+export function getDDayDisplay(
+  startDate: string,
+  endDate: string,
+  today?: Date
+): DDayDisplay {
+  const phase = getChallengePhase(startDate, endDate, today);
+
+  if (phase === 'before') {
+    const untilStart = getDaysUntilStart(startDate, today);
+    const d = untilStart ?? 0;
+    return {
+      label: d === 0 ? '시작 D-DAY' : `시작 D-${d}`,
+      ariaLabel: d === 0 ? '오늘 챌린지 시작' : `시작까지 ${d}일 남음`,
+      tone: 'info',
+      endingSoon: false,
+    };
+  }
+
+  if (phase === 'ended') {
+    return {
+      label: '종료',
+      ariaLabel: '종료된 챌린지',
+      tone: 'ended',
+      endingSoon: false,
+    };
+  }
+
+  // active
+  const untilEnd = getDaysUntilEnd(endDate, today);
+  if (untilEnd == null) {
+    return { label: '진행 중', ariaLabel: '진행 중인 챌린지', tone: 'default', endingSoon: false };
+  }
+  if (untilEnd === 0) {
+    return {
+      label: 'D-DAY',
+      ariaLabel: '오늘 챌린지 종료',
+      tone: 'warning',
+      endingSoon: true,
+    };
+  }
+  return {
+    label: `D-${untilEnd}`,
+    ariaLabel: `종료까지 ${untilEnd}일 남음`,
+    tone: untilEnd <= 3 ? 'warning' : 'default',
+    endingSoon: untilEnd <= 1,
+  };
+}

--- a/burnfat/src/lib/oneTimeNotice.ts
+++ b/burnfat/src/lib/oneTimeNotice.ts
@@ -1,0 +1,32 @@
+/**
+ * Sprint 1 — 일회성 안내 노출 가드.
+ *
+ * "이 챌린지에서 이 안내를 이미 봤는가" 를 localStorage 로 기록한다.
+ * 토스트·배너 등 *1회만 노출* 하고 싶은 안내에 공용으로 쓴다.
+ *
+ * 키 예시: `backfill:<challengeId>`, `endingSoon:<challengeId>`.
+ */
+
+const PREFIX = 'burnfat:notice:';
+
+/**
+ * 해당 안내를 이미 봤으면 true.
+ * localStorage 접근 실패 시에도 true 를 반환해 *반복 노출(스팸) 을 막는* 보수적 처리.
+ */
+export function hasSeenNotice(key: string): boolean {
+  if (!key) return true;
+  try {
+    return localStorage.getItem(`${PREFIX}${key}`) != null;
+  } catch {
+    return true;
+  }
+}
+
+export function markNoticeSeen(key: string): void {
+  if (!key) return;
+  try {
+    localStorage.setItem(`${PREFIX}${key}`, new Date().toISOString());
+  } catch {
+    // 무시
+  }
+}

--- a/burnfat/src/lib/participantIdentity.ts
+++ b/burnfat/src/lib/participantIdentity.ts
@@ -1,0 +1,47 @@
+/**
+ * Sprint 1 — "내 참가자 식별".
+ *
+ * 신뢰 기반 공개형 모델에서 *인증* 은 device_secret(쓰기 잠금) 이 담당한다.
+ * 이 모듈은 인증이 아니라 *UX 편의를 위한 식별* 만 다룬다 —
+ * "이 디바이스에서 마지막으로 이 챌린지에 등록·선택한 참가자가 누구인가".
+ *
+ * 챌린지당 1명을 localStorage 에 매핑한다. 키: `burnfat:identity:<challengeId>`.
+ * 값이 실제 참가자와 불일치(삭제됨 등)할 수 있으므로, 호출 측은
+ * 반환된 id 가 현재 참가자 목록에 존재하는지 반드시 검증해야 한다.
+ */
+
+const KEY_PREFIX = 'burnfat:identity:';
+
+function keyFor(challengeId: string): string {
+  return `${KEY_PREFIX}${challengeId}`;
+}
+
+/** 이 디바이스의 "나" 를 해당 챌린지에 대해 기억한다. */
+export function rememberParticipant(challengeId: string, participantId: string): void {
+  if (!challengeId || !participantId) return;
+  try {
+    localStorage.setItem(keyFor(challengeId), participantId);
+  } catch {
+    // localStorage 미지원/할당 초과는 무시 — 식별은 부가 기능이라 실패해도 앱은 동작.
+  }
+}
+
+/** 기억된 참가자 id 를 반환. 없으면 null. */
+export function getRememberedParticipantId(challengeId: string): string | null {
+  if (!challengeId) return null;
+  try {
+    return localStorage.getItem(keyFor(challengeId));
+  } catch {
+    return null;
+  }
+}
+
+/** 식별 해제 ("내가 아니에요"). */
+export function forgetParticipant(challengeId: string): void {
+  if (!challengeId) return;
+  try {
+    localStorage.removeItem(keyFor(challengeId));
+  } catch {
+    // 무시
+  }
+}

--- a/burnfat/src/lib/prizeDistribution.test.ts
+++ b/burnfat/src/lib/prizeDistribution.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { computePrizeDistribution, formatKrw } from './prizeDistribution';
+
+describe('computePrizeDistribution', () => {
+  it('참가비 5만원 × 5명 → 풀 25만, 1등 +20만, 나머지 -5만', () => {
+    const d = computePrizeDistribution(50000, 5);
+    expect(d.pot).toBe(250000);
+    expect(d.winnerNet).toBe(200000);
+    expect(d.loserNet).toBe(-50000);
+    expect(d.hasPrize).toBe(true);
+  });
+
+  it('참가자 1명이면 분배 의미 없음 (hasPrize=false)', () => {
+    const d = computePrizeDistribution(50000, 1);
+    expect(d.pot).toBe(50000);
+    expect(d.hasPrize).toBe(false);
+  });
+
+  it('참가비 0원이면 hasPrize=false', () => {
+    const d = computePrizeDistribution(0, 5);
+    expect(d.pot).toBe(0);
+    expect(d.hasPrize).toBe(false);
+  });
+
+  it('음수/소수 입력은 정규화', () => {
+    const d = computePrizeDistribution(-100, 3.9);
+    expect(d.stakeAmount).toBe(0);
+    expect(d.participantCount).toBe(3);
+  });
+});
+
+describe('formatKrw', () => {
+  it('천 단위 구분 + 원 접미', () => {
+    expect(formatKrw(250000)).toBe('250,000원');
+    expect(formatKrw(0)).toBe('0원');
+  });
+
+  it('음수는 - 접두', () => {
+    expect(formatKrw(-50000)).toBe('-50,000원');
+  });
+});

--- a/burnfat/src/lib/prizeDistribution.ts
+++ b/burnfat/src/lib/prizeDistribution.ts
@@ -1,0 +1,49 @@
+/**
+ * Sprint 1 — 상금 분배 계산.
+ *
+ * BurnFat 은 *지인 내기* 모델이다. 각 참가자가 `stakeAmount` 원을 걸고,
+ * 전체 상금 풀(`pot`) 은 `stakeAmount × 참가자 수`.
+ *
+ * 분배 규칙은 대결방마다 합의로 달라질 수 있으나, 제품이 명시 규칙을 정하기 전까지는
+ * 가장 흔한 *승자독식(1등 전액 획득)* 을 기본 가정으로 보여 준다. 공유 카드에는
+ * 이것이 "예상" 정산임을 캡션으로 함께 명시한다.
+ */
+
+export const PRIZE_RULE_LABEL = '1등 전액 획득 (승자독식)';
+
+export interface PrizeDistribution {
+  /** 전체 상금 풀 = stakeAmount × participantCount. */
+  pot: number;
+  participantCount: number;
+  stakeAmount: number;
+  /** 1등 순이익 = pot − 본인 참가비. */
+  winnerNet: number;
+  /** 2등 이하 순손실 = −본인 참가비 (참가자 2명 이상일 때). */
+  loserNet: number;
+  /** 분배 금액이 의미 있는지 (참가비>0 && 참가자 2명 이상). */
+  hasPrize: boolean;
+}
+
+export function computePrizeDistribution(
+  stakeAmount: number,
+  participantCount: number
+): PrizeDistribution {
+  const stake = Math.max(0, Math.round(stakeAmount || 0));
+  const count = Math.max(0, Math.floor(participantCount || 0));
+  const pot = stake * count;
+  return {
+    pot,
+    participantCount: count,
+    stakeAmount: stake,
+    winnerNet: pot - stake,
+    loserNet: -stake,
+    hasPrize: stake > 0 && count >= 2,
+  };
+}
+
+/** 원화 표기 — 음수는 "-" 접두. 예: 250000 → "250,000원", -50000 → "-50,000원". */
+export function formatKrw(amount: number): string {
+  const abs = Math.abs(Math.round(amount));
+  const sign = amount < 0 ? '-' : '';
+  return `${sign}${abs.toLocaleString('ko-KR')}원`;
+}

--- a/burnfat/src/pages/ChallengePage.tsx
+++ b/burnfat/src/pages/ChallengePage.tsx
@@ -50,7 +50,18 @@ import WeeklyLogsUpgradeNoticeDialog, {
 } from '../components/WeeklyLogsUpgradeNoticeDialog';
 import { useAllWeeklyLogsForChallenge } from '../hooks/useWeeklyLogs';
 import { useRecordStatus } from '../hooks/useRecordStatus';
+import { useParticipantIdentity } from '../hooks/useParticipantIdentity';
+import { useNextRecordableWeek } from '../hooks/useNextRecordableWeek';
 import { resolveImageUrl } from '../lib/signedImage';
+import { getDDayDisplay } from '../lib/challengeSchedule';
+import { hasSeenNotice, markNoticeSeen } from '../lib/oneTimeNotice';
+import MyStatusCard from '../components/MyStatusCard';
+import DDayChip from '../components/DDayChip';
+import EndingSoonDialog, {
+  shouldShowEndingSoonNotice,
+  dismissEndingSoonNotice,
+} from '../components/EndingSoonDialog';
+import RankingShareDialog from '../components/RankingShareDialog';
 
 // Sprint 0.4: 디버그 플래그를 빌드 시점 환경 변수로 분리.
 //   - VITE_DEBUG_SHOW_RANKING="true"           → 순위 항상 공개 (개발 전용)
@@ -121,6 +132,10 @@ export default function ChallengePage() {
   const [editLoading, setEditLoading] = useState(false);
   const [editError, setEditError] = useState('');
   const [loadingElapsedMs, setLoadingElapsedMs] = useState(0);
+  // Sprint 1: 개인 상태 카드 / 종료 임박 모달 / 랭킹 공유
+  const [showJoinForm, setShowJoinForm] = useState(false);
+  const [endingSoonOpen, setEndingSoonOpen] = useState(false);
+  const [rankingShareOpen, setRankingShareOpen] = useState(false);
 
   const fetchChallenge = useCallback(async () => {
     if (!code) {
@@ -229,21 +244,10 @@ export default function ChallengePage() {
     setWeeklyLogsNoticeOpen(false);
   };
 
-  const handleShareRanking = () => {
+  // Sprint 1: 결과 공유는 RankingShareDialog (PNG 이미지 + 텍스트) 로 일원화.
+  const handleOpenRankingShare = () => {
     if (!challenge || ranking.length === 0) return;
-    const medal = (n: number) => n === 1 ? '🥇' : n === 2 ? '🥈' : n === 3 ? '🥉' : `${n}위`;
-    const lines = [
-      `🔥 BurnFat 대결 결과`,
-      `📌 ${challenge.title}`,
-      `📅 ${challenge.start_date} ~ ${challenge.end_date}`,
-      '',
-      ...ranking.map((r) => `${medal(r.rank)} ${r.nickname}  -${r.reductionRate.toFixed(2)}%`),
-      '',
-      `🔗 ${shareUrl}`,
-    ];
-    navigator.clipboard.writeText(lines.join('\n')).then(() =>
-      setToast('결과가 클립보드에 복사되었습니다')
-    );
+    setRankingShareOpen(true);
   };
 
   const openPinDialog = (action: 'ranking' | 'editChallenge') => {
@@ -392,13 +396,49 @@ export default function ChallengePage() {
     setError('');
     setJoinNickname('');
     fetchParticipants();
+    // Sprint 1: 방금 등록한 참가자를 이 디바이스의 "나" 로 기억 → 재방문 시 개인 상태 카드.
+    rememberMe((newParticipant as ParticipantWithSubmissions).id);
+    setShowJoinForm(false);
     setBasicInfoDialog({ ...(newParticipant as ParticipantWithSubmissions), submissions: [] });
     setBasicInfoDialogAfterJoin(true);
   };
 
   const participantIds = participants.map((p) => p.id);
-  const { logsByParticipant, refetch: refetchLogs } = useAllWeeklyLogsForChallenge(participantIds);
+  const { logsByParticipant, loading: logsLoading, refetch: refetchLogs } =
+    useAllWeeklyLogsForChallenge(participantIds);
   const recordStatus = useRecordStatus(participants, logsByParticipant, challenge?.start_date || '');
+
+  // Sprint 1: 내 참가자 식별 + 내 주간 기록 상태
+  const { myParticipant, remember: rememberMe, forget: forgetMe } = useParticipantIdentity(
+    challenge?.id,
+    participants
+  );
+  const myWeekly = useNextRecordableWeek(
+    myParticipant ? logsByParticipant[myParticipant.id] || [] : [],
+    challenge?.start_date || '',
+    challenge?.end_date || ''
+  );
+
+  // Sprint 1: 종료 임박 모달 — 종료 24h 이내 진입 시 챌린지당 1회
+  useEffect(() => {
+    if (!challenge) return;
+    const dd = getDDayDisplay(challenge.start_date, challenge.end_date);
+    if (dd.endingSoon && shouldShowEndingSoonNotice(challenge.id)) {
+      setEndingSoonOpen(true);
+    }
+  }, [challenge]);
+
+  // Sprint 1: 백필 권고 토스트 — 내 미입력 주차가 2개 이상이면 챌린지당 1회
+  useEffect(() => {
+    if (!challenge || !myParticipant || logsLoading) return;
+    if (myWeekly.missingWeeks.length < 2) return;
+    const key = `backfill:${challenge.id}:${myParticipant.id}`;
+    if (hasSeenNotice(key)) return;
+    setToast(
+      `미입력 주차가 ${myWeekly.missingWeeks.length}개 있어요. 채워두면 AI 조언이 더 정확해집니다.`
+    );
+    markNoticeSeen(key);
+  }, [challenge, myParticipant, logsLoading, myWeekly.missingWeeks.length]);
 
   if (loading) {
     if (loadingElapsedMs < 300) {
@@ -448,6 +488,24 @@ export default function ChallengePage() {
   // end_date가 없으면 안전하게 차단(모달 열지 않음). 빈 문자열일 때 '' > today 는 false가 되어 잘못 모달이 열리는 버그 방지
   const isBeforeEndDate = !endDateOnly ? true : endDateOnly > today;
 
+  // Sprint 1: D-Day 표시 모델 (헤더 칩 + 종료 임박 모달이 공유)
+  const dday = getDDayDisplay(challenge.start_date, challenge.end_date);
+
+  // Sprint 1: 시작/종료 인증 모달 진입 — 개인 상태 카드와 참가자 카드가 공유.
+  const openStartAuth = (p: ParticipantWithSubmissions) => {
+    if (isBeforeStartDate) {
+      setToast(`시작일(${challenge.start_date}) 이후에 인증을 권장하지만, 미리 제출도 가능합니다.`);
+    }
+    setSubmitModal({ open: true, participantId: p.id, participantNickname: p.nickname, type: 'start' });
+  };
+  const openEndAuth = (p: ParticipantWithSubmissions) => {
+    if (isBeforeEndDate && !DEBUG_ALLOW_EARLY_END_SUBMIT) {
+      setEarlyEndBlockSnackbar(true);
+    } else {
+      setSubmitModal({ open: true, participantId: p.id, participantNickname: p.nickname, type: 'end' });
+    }
+  };
+
   const participantsWithStart = participants.filter((p) => p.submissions.some((s) => s.type === 'start'));
   const allEndComplete = participantsWithStart.length > 0 && participantsWithStart.every((p) =>
     p.submissions.some((s) => s.type === 'end')
@@ -489,46 +547,89 @@ export default function ChallengePage() {
               대결 코드: <strong>{challenge.code}</strong>
             </Typography>
           </Box>
-          <Box sx={{ display: 'flex', gap: 0.5 }}>
-            <Tooltip title="챌린지 정보 수정">
-              <IconButton onClick={handleEditChallengeOpen} size="small" color="default">
-                <EditIcon />
-              </IconButton>
-            </Tooltip>
-            <Tooltip title="URL 복사">
-              <IconButton onClick={handleCopyShare} color="primary" size="small">
-                <ContentCopyIcon />
-              </IconButton>
-            </Tooltip>
+          <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 0.5 }}>
+            <DDayChip dday={dday} />
+            <Box sx={{ display: 'flex', gap: 0.5 }}>
+              <Tooltip title="챌린지 정보 수정">
+                <IconButton
+                  onClick={handleEditChallengeOpen}
+                  size="small"
+                  color="default"
+                  aria-label="챌린지 정보 수정"
+                >
+                  <EditIcon />
+                </IconButton>
+              </Tooltip>
+              <Tooltip title="URL 복사">
+                <IconButton
+                  onClick={handleCopyShare}
+                  color="primary"
+                  size="small"
+                  aria-label="대결 URL 복사"
+                >
+                  <ContentCopyIcon />
+                </IconButton>
+              </Tooltip>
+            </Box>
           </Box>
         </Box>
       </Box>
 
       {tab === 0 && (
-        <Card sx={{ mx: 2, mb: 2 }}>
-          <CardContent sx={{ p: 2 }}>
-            <Typography variant="subtitle2" color="text.secondary" gutterBottom>
-              참가하기
-            </Typography>
-            <form onSubmit={handleJoin} style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
-              <TextField
-                size="small"
-                placeholder="닉네임"
-                value={joinNickname}
-                onChange={(e) => setJoinNickname(e.target.value)}
-                sx={{ flex: 1, minWidth: 0, '& .MuiInputBase-root': { minHeight: 40 } }}
-              />
-              <Button type="submit" variant="contained" size="small" disabled={joinLoading || !joinNickname.trim()} sx={{ minWidth: 80, minHeight: 40 }}>
-                참가
+        myParticipant && !showJoinForm ? (
+          <>
+            <MyStatusCard
+              participant={myParticipant}
+              logs={logsByParticipant[myParticipant.id] || []}
+              challengeStartDate={challenge.start_date}
+              challengeEndDate={challenge.end_date}
+              onAuthStart={() => openStartAuth(myParticipant)}
+              onAuthEnd={() => openEndAuth(myParticipant)}
+              onOpenWeeklyLog={(weekNo) => {
+                setTab(2);
+                setWeeklyLogTarget({ participant: myParticipant, defaultWeekNo: weekNo });
+              }}
+              onForget={forgetMe}
+            />
+            <Box sx={{ px: 2, mb: 1, textAlign: 'center' }}>
+              <Button size="small" variant="text" onClick={() => setShowJoinForm(true)}>
+                + 다른 참가자 추가
               </Button>
-            </form>
-            {error && (
-              <Typography color="error" variant="caption" sx={{ mt: 1, display: 'block' }}>
-                {error}
-              </Typography>
-            )}
-          </CardContent>
-        </Card>
+            </Box>
+          </>
+        ) : (
+          <Card sx={{ mx: 2, mb: 2 }}>
+            <CardContent sx={{ p: 2 }}>
+              <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 0.5 }}>
+                <Typography variant="subtitle2" color="text.secondary">
+                  참가하기
+                </Typography>
+                {myParticipant && (
+                  <Button size="small" variant="text" color="inherit" onClick={() => setShowJoinForm(false)}>
+                    취소
+                  </Button>
+                )}
+              </Box>
+              <form onSubmit={handleJoin} style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+                <TextField
+                  size="small"
+                  placeholder="닉네임"
+                  value={joinNickname}
+                  onChange={(e) => setJoinNickname(e.target.value)}
+                  sx={{ flex: 1, minWidth: 0, '& .MuiInputBase-root': { minHeight: 40 } }}
+                />
+                <Button type="submit" variant="contained" size="small" disabled={joinLoading || !joinNickname.trim()} sx={{ minWidth: 80, minHeight: 40 }}>
+                  참가
+                </Button>
+              </form>
+              {error && (
+                <Typography color="error" variant="caption" sx={{ mt: 1, display: 'block' }}>
+                  {error}
+                </Typography>
+              )}
+            </CardContent>
+          </Card>
+        )
       )}
 
       <Tabs
@@ -585,7 +686,12 @@ export default function ChallengePage() {
                     </Box>
                     <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
                       <Tooltip title="기본정보 수정">
-                        <IconButton size="small" onClick={() => { setBasicInfoDialog(p); setBasicInfoDialogAfterJoin(false); }} sx={{ p: 0.5, minWidth: 44, minHeight: 44 }}>
+                        <IconButton
+                          size="small"
+                          onClick={() => { setBasicInfoDialog(p); setBasicInfoDialogAfterJoin(false); }}
+                          sx={{ p: 0.5, minWidth: 44, minHeight: 44 }}
+                          aria-label={`${p.nickname} 기본정보 수정`}
+                        >
                           <EditIcon sx={{ fontSize: 18 }} />
                         </IconButton>
                       </Tooltip>
@@ -594,25 +700,14 @@ export default function ChallengePage() {
                           size="small"
                           variant="outlined"
                           startIcon={<AddIcon sx={{ fontSize: 16 }} />}
-                          onClick={() => {
-                            if (isBeforeStartDate) {
-                              setToast(`시작일(${challenge.start_date}) 이후에 인증을 권장하지만, 미리 제출도 가능합니다.`);
-                            }
-                            setSubmitModal({ open: true, participantId: p.id, participantNickname: p.nickname, type: 'start' });
-                          }}
+                          onClick={() => openStartAuth(p)}
                           sx={{ minHeight: 44, py: 0.75, px: 1.5, fontSize: '0.8125rem' }}
                         >
                           시작일 인증
                         </Button>
                       )}
                       {!p.submissions.some((s) => s.type === 'end') && (() => {
-                        const handleEndClick = () => {
-                          if (isBeforeEndDate && !DEBUG_ALLOW_EARLY_END_SUBMIT) {
-                            setEarlyEndBlockSnackbar(true);
-                          } else {
-                            setSubmitModal({ open: true, participantId: p.id, participantNickname: p.nickname, type: 'end' });
-                          }
-                        };
+                        const handleEndClick = () => openEndAuth(p);
                         const { main, glow } = getEndBtnColor(p.id);
                         const glowDim = glow.replace('0.5)', '0.4)');
                         return (
@@ -784,7 +879,7 @@ export default function ChallengePage() {
                   variant="outlined"
                   size="small"
                   startIcon={<ShareIcon />}
-                  onClick={handleShareRanking}
+                  onClick={handleOpenRankingShare}
                   sx={{ flexShrink: 0, minHeight: 44 }}
                 >
                   결과 공유
@@ -851,6 +946,8 @@ export default function ChallengePage() {
                           {medal ? (
                             <Box
                               component="span"
+                              role="img"
+                              aria-label={`${r.rank}위`}
                               sx={{
                                 fontSize: 32,
                                 lineHeight: 1,
@@ -1122,6 +1219,32 @@ export default function ChallengePage() {
             fetchParticipants();
             refetchLogs();
           }}
+        />
+      )}
+
+      {/* Sprint 1: 종료 임박 모달 */}
+      <EndingSoonDialog
+        open={endingSoonOpen}
+        ddayLabel={dday.label}
+        endDate={endDateOnly || challenge.end_date}
+        myEndPending={myParticipant ? !myParticipant.submissions.some((s) => s.type === 'end') : undefined}
+        onClose={() => {
+          dismissEndingSoonNotice(challenge.id);
+          setEndingSoonOpen(false);
+        }}
+        onAuthEnd={myParticipant ? () => openEndAuth(myParticipant) : undefined}
+      />
+
+      {/* Sprint 1: 랭킹 공유 (PNG + 텍스트) */}
+      {rankingShareOpen && (
+        <RankingShareDialog
+          open={rankingShareOpen}
+          challenge={challenge}
+          ranking={ranking}
+          participantCount={participants.length}
+          shareUrl={shareUrl}
+          onClose={() => setRankingShareOpen(false)}
+          onToast={(msg) => setToast(msg)}
         />
       )}
     </Box>


### PR DESCRIPTION
## Summary
Sprint 1 (UX 빠른 승) — 재방문 사용자의 다음 행동 유도 + 공유 루프 강화. 모두 순수 클라이언트 변경 (DB·RLS·Storage·백엔드 무변경).

- **개인 상태 카드**: `participantIdentity.ts`(localStorage 챌린지당 1명 매핑) + `useParticipantIdentity` hook + `MyStatusCard`(시작/종료/이번 주 상태를 아이콘+텍스트 병행, 미완료 인라인 CTA).
- **D-Day**: `challengeSchedule.ts`(`getDDayDisplay`) + `DDayChip`(헤더) + `EndingSoonDialog`(종료 24h 이내 진입 시 챌린지당 1회).
- **랭킹 공유**: `prizeDistribution.ts`(승자독식 예상 정산) + `RankingShareDialog`(html-to-image PNG → Web Share/다운로드 + 텍스트 복사).
- **a11y 1차 패스**: IconButton aria-label, 메달 `role=img`+`aria-label`, 차트 컨테이너 `role=img`+alt-text, 라인 점선/실선 병행.
- **백필 토스트**: `oneTimeNotice.ts` 가드 + 내 미입력 주차 2개 이상 시 챌린지당 1회 (Sprint 1.5 핸드오프 §4.1 활성화).

상세: `burnfat/docs/SPRINT1_HANDOFF.md` · 로드맵: `IMPROVEMENT_REPORT_2026-05.md` §6 Sprint 1

## Test plan
- [x] `npx tsc --noEmit` 클린
- [x] `npm run build` 성공
- [x] `npm test` 29/29 통과 (challengeSchedule 11 + prizeDistribution 6 + useNextRecordableWeek 12)
- [ ] 배포 후: 개인 상태 카드 재방문 식별 / D-Day 칩 / 종료 임박 모달 1회 / 랭킹 공유 PNG·텍스트 / 메달 스크린리더 / 백필 토스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)