### PR TITLE
feat(burnfat): Sprint 2 — 제품 가치 확장

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ crossfit-system/
 | **0** | 보안 응급 처치 (PIN 해시 / UPDATE 잠금 / 이미지 signed URL / 디버그 플래그) | ✅ **완료** — commit `64315d3`, 프로덕션 배포·DB 적용·검증 완료. 상세: [`burnfat/docs/SPRINT0_HANDOFF.md`](burnfat/docs/SPRINT0_HANDOFF.md) |
 | **1** | UX 빠른 승 (개인 상태 카드 / D-Day / 랭킹 공유 이미지 / a11y 1차 패스) | ✅ **완료** — `MyStatusCard`+`useParticipantIdentity` / `DDayChip`+`EndingSoonDialog` / `RankingShareDialog`(html-to-image) / a11y(aria-label·role=img·메달 텍스트·라인 점선) / 백필 토스트 + vitest 29/29. 상세: [`burnfat/docs/SPRINT1_HANDOFF.md`](burnfat/docs/SPRINT1_HANDOFF.md) |
 | **1.5** | 주간 기록 입력 UX 정상화 (다음 차주 CTA / placeholder / `useNextRecordableWeek`) | ✅ **완료** — `useNextRecordableWeek` hook + 영구 CTA + 미입력 주차 placeholder + WeeklyLogForm 충돌 차단 + 누적 입력률 막대 + vitest 12/12. 상세: [`burnfat/docs/SPRINT1_5_HANDOFF.md`](burnfat/docs/SPRINT1_5_HANDOFF.md) |
-| **2** | AI 조언 서버 캐시 + JSON 응답 / 목표 진행률 / 챌린지 템플릿 | ⏳ 미착수 |
+| **2** | AI 조언 서버 캐시 + JSON 응답 / 목표 진행률 / 챌린지 템플릿 | ✅ **완료 (코드)** — `weekly_ai_advice` 캐시 테이블 + `burnfat_ai.py` JSON 구조화·서버 캐시·입력 가드 / `GoalProgressWidget`+`goalProgress.ts` / `ChallengeTemplatePicker`+`challengeTemplates.ts` + vitest 44/44. ⚠️ 마이그레이션·백엔드 배포 필요. 상세: [`burnfat/docs/SPRINT2_HANDOFF.md`](burnfat/docs/SPRINT2_HANDOFF.md) |
 | **2.5** | 대화형 코치 모달 + 세션·장기 메모리 영속화 | ⏳ 미착수 |
 | **3** | ChallengePage 분해 / N+1 제거 / 테스트 베이스라인 | ⏳ 미착수 (Sprint 1.5 에서 vitest 최소 셋업만 선 도입) |
 

--- a/backend/routes/burnfat_ai.py
+++ b/backend/routes/burnfat_ai.py
@@ -2,14 +2,26 @@
 BurnFat AI 조언 - Grok (xAI) 프록시 엔드포인트.
 
 - Supabase REST API를 통해 참가자/주간 기록/챌린지 정보 조회
-- xAI Grok API (OpenAI 호환)로 조언 생성
+- xAI Grok API (OpenAI 호환)로 조언 생성 — JSON 구조화 응답
+- weekly_ai_advice 테이블에 (participant_id, week_no, prompt_version) 단위 서버 캐시
 - CORS: 전역 CORS 설정(app.py)이 /api/* 에 적용되므로 별도 처리 불필요
+
+Sprint 2 변경
+  - 응답을 단일 문자열 → 구조화 JSON({summary, action_items[], cautions[]}) 으로 격상.
+    `advice` 평문 필드는 구버전 클라이언트 호환을 위해 그대로 유지(구조화 필드로부터 합성).
+  - weekly_ai_advice 서버 캐시 — 같은 주차/참가자 조언을 친구가 열어도 Grok 재호출 없음.
+    캐시 신선도는 updated_at 기준 24h TTL. force_refresh / 사용자 추가 입력 시 우회.
+  - 캐시 테이블이 아직 없거나(마이그레이션 미적용) 일시 오류여도 *조언 생성 자체는 동작*
+    하도록 모든 캐시 연산을 graceful degrade 처리 → 백엔드/마이그레이션 배포 순서 무관.
+  - 입력 가드: user_context 길이 제한, advice_style/advice_goal 화이트리스트.
 """
 
 from __future__ import annotations
 
+import json
 import logging
 import os
+from datetime import date, datetime, timedelta, timezone
 from typing import Any
 
 import requests
@@ -21,8 +33,28 @@ logger = logging.getLogger(__name__)
 
 XAI_API_URL = "https://api.x.ai/v1/chat/completions"
 XAI_MODEL = os.environ.get("XAI_MODEL", "grok-4-1-fast-non-reasoning")
-XAI_MAX_TOKENS = int(os.environ.get("XAI_MAX_TOKENS", "500"))
+XAI_MAX_TOKENS = int(os.environ.get("XAI_MAX_TOKENS", "700"))
 XAI_TIMEOUT_SECONDS = int(os.environ.get("XAI_TIMEOUT_SECONDS", "30"))
+
+# 프롬프트/응답 스키마 버전. 프롬프트가 바뀌면 올려서 과거 캐시를 자연 무효화.
+PROMPT_VERSION = "sprint2-json-v1"
+CACHE_TTL_HOURS = 24
+
+# 입력 가드 (프롬프트 비용 폭주·오용 방지)
+USER_CONTEXT_MAX_CHARS = 500
+ADVICE_STYLE_WHITELIST = {
+    "현실적으로",
+    "엄격하게",
+    "동기부여 중심으로",
+    "식단 중심으로",
+    "운동 중심으로",
+}
+ADVICE_GOAL_WHITELIST = {
+    "이번 주 전략",
+    "정체 원인 분석",
+    "식단/운동 피드백",
+    "동기부여",
+}
 
 SYSTEM_PROMPT = """당신은 체지방 감량 다이어트 전문 코치입니다.
 참가자의 주간 데이터(체지방률, 몸무게, 운동 횟수, 수면 시간, 식단 패턴 등)를 분석하여
@@ -34,20 +66,10 @@ SYSTEM_PROMPT = """당신은 체지방 감량 다이어트 전문 코치입니�
    - 체지방이 정체되거나 증가한 주가 있다면, 같은 주의 수면·식단·운동 데이터에서 원인을 찾으세요.
 2. 기록된 데이터만 분석에 사용하세요.
    - 운동 횟수가 기록된 경우 → 빈도와 체지방 변화의 상관관계를 언급하세요.
-   - 수면 시간이 기록된 경우 → 6시간 미만이면 코르티솔 상승으로 지방 분해 저해 가능성을 구체적으로 언급하세요.
+   - 수면 시간이 기록된 경우 → 6시간 미만이면 코르티솔 상승으로 지방 분해 저해 가능성을 언급하세요.
    - 식단 패턴이 기록된 경우 → 과식/절식 주와 체중·체지방 변화를 연결하여 분석하세요.
-3. 반드시 이번 주에 실천할 구체적인 행동 1~2가지를 숫자와 함께 제시하세요.
-   예) "이번 주는 운동 4회 + 수면 7시간 확보를 목표로 하세요."
-4. 사용자가 추가로 입력한 현재 상황/고민/선호 조언 스타일이 있으면, 최신 맥락으로 우선 반영하세요.
+3. 사용자가 추가로 입력한 현재 상황/고민/선호 조언 스타일이 있으면 최신 맥락으로 우선 반영하세요.
    단, 사용자의 설명과 기록 데이터가 충돌하면 기록 수치를 근거로 조심스럽게 해석하세요.
-
-## 출력 형식
-- 3~5문장으로 작성하세요.
-- 첫 문장에서 전체 추이를 한 줄로 요약하세요.
-- 일반적인 조언("단백질을 먹어라", "운동하라")만 반복하지 마세요.
-  반드시 실제 기록 수치를 인용해서 말하세요.
-- 마지막 문장은 이번 주 실천 행동으로 끝내세요.
-- 반드시 한국어로 답변하세요.
 
 ## 체지방 변화 판단 기준
 - 주 0.3~0.5%p 감소: 이상적인 속도 (유지 권장)
@@ -55,8 +77,24 @@ SYSTEM_PROMPT = """당신은 체지방 감량 다이어트 전문 코치입니�
 - 변화 없거나 증가: 수분·호르몬·주기 요인 OR 식단·운동 패턴 재점검
 - 수면 6시간 미만: 코르티솔 상승 → 지방 분해 저해 — 수면 회복 최우선 권유
 - 운동 2회 이하: 횟수 증가 또는 강도 조정 제안
-- 과식 주간: 같은 주의 체중·체지방 변화와 함께 해석하여 피드백"""
 
+## 출력 형식 (매우 중요)
+반드시 아래 JSON 스키마를 따르는 JSON 객체 **하나만** 반환하세요. JSON 외 다른 텍스트를 절대 포함하지 마세요.
+
+{
+  "summary": "전체 추이를 한 문장으로 요약. 반드시 실제 기록 수치를 인용.",
+  "action_items": ["이번 주에 실천할 구체적 행동. 숫자를 포함. 1~3개. 예: '운동 4회 + 수면 7시간 확보'"],
+  "cautions": ["주의하거나 점검할 점. 0~2개. 없으면 빈 배열."]
+}
+
+- 모든 문자열은 한국어로 작성하세요.
+- 일반론("단백질을 먹어라")만 반복하지 말고 반드시 실제 기록 수치를 인용하세요.
+- action_items 는 측정 가능한 행동으로 작성하세요."""
+
+
+# --------------------------------------------------------------------------
+# Supabase REST 헬퍼
+# --------------------------------------------------------------------------
 
 def _get_supabase_config() -> tuple[str | None, str | None]:
     url = os.environ.get("SUPABASE_URL", "").rstrip("/")
@@ -87,6 +125,34 @@ def _supabase_get(path: str, params: dict[str, str]) -> list[dict[str, Any]]:
     return data if isinstance(data, list) else []
 
 
+def _supabase_upsert(path: str, body: dict[str, Any], on_conflict: str) -> None:
+    """PostgREST upsert (merge-duplicates). on_conflict 는 UNIQUE 제약 컬럼 목록."""
+    url, key = _get_supabase_config()
+    if not url or not key:
+        raise RuntimeError("Supabase not configured")
+    headers = {
+        "apikey": key,
+        "Authorization": f"Bearer {key}",
+        "Content-Type": "application/json",
+        "Prefer": "resolution=merge-duplicates,return=minimal",
+    }
+    resp = requests.post(
+        f"{url}{path}",
+        params={"on_conflict": on_conflict},
+        json=body,
+        headers=headers,
+        timeout=10,
+    )
+    if not resp.ok:
+        logger.error(
+            "Supabase upsert error %s: status=%s body=%s",
+            path,
+            resp.status_code,
+            (resp.text or "")[:500],
+        )
+    resp.raise_for_status()
+
+
 def _fetch_participant(participant_id: str) -> dict[str, Any] | None:
     rows = _supabase_get(
         "/rest/v1/participants",
@@ -113,6 +179,90 @@ def _fetch_challenge_dates(challenge_id: Any) -> tuple[str, str]:
         return "", ""
     return str(rows[0].get("start_date") or ""), str(rows[0].get("end_date") or "")
 
+
+# --------------------------------------------------------------------------
+# 주차 계산 + 캐시
+# --------------------------------------------------------------------------
+
+def _compute_week_no(start_date: str) -> int:
+    """챌린지 시작일 기준 오늘이 속한 주차 (1-base). 시작 전이면 1."""
+    if not start_date:
+        return 1
+    try:
+        start = date.fromisoformat(start_date[:10])
+    except ValueError:
+        return 1
+    diff_days = (date.today() - start).days
+    if diff_days < 0:
+        return 1
+    return diff_days // 7 + 1
+
+
+def _is_fresh(updated_at: str | None) -> bool:
+    if not updated_at:
+        return False
+    try:
+        ts = datetime.fromisoformat(str(updated_at).replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=timezone.utc)
+    return datetime.now(timezone.utc) - ts < timedelta(hours=CACHE_TTL_HOURS)
+
+
+def _fetch_cached_advice(participant_id: str, week_no: int) -> dict[str, Any] | None:
+    """캐시 조회. 테이블 미존재/일시 오류는 캐시 미스로 처리(graceful degrade)."""
+    try:
+        rows = _supabase_get(
+            "/rest/v1/weekly_ai_advice",
+            {
+                "participant_id": f"eq.{participant_id}",
+                "week_no": f"eq.{week_no}",
+                "prompt_version": f"eq.{PROMPT_VERSION}",
+                "select": "*",
+                "order": "updated_at.desc",
+                "limit": "1",
+            },
+        )
+    except (requests.RequestException, RuntimeError) as e:
+        logger.warning("weekly_ai_advice cache read skipped: %s", e)
+        return None
+    if not rows:
+        return None
+    row = rows[0]
+    if not _is_fresh(row.get("updated_at")):
+        return None
+    return row
+
+
+def _store_advice(
+    participant_id: str,
+    week_no: int,
+    advice_md: str,
+    advice_json: dict[str, Any],
+) -> None:
+    """캐시 저장(upsert). 실패해도 조언 응답 자체는 진행되도록 예외를 흡수."""
+    try:
+        _supabase_upsert(
+            "/rest/v1/weekly_ai_advice",
+            {
+                "participant_id": participant_id,
+                "week_no": week_no,
+                "prompt_version": PROMPT_VERSION,
+                "advice_md": advice_md,
+                "advice_json": advice_json,
+                "model": XAI_MODEL,
+                "updated_at": datetime.now(timezone.utc).isoformat(),
+            },
+            on_conflict="participant_id,week_no,prompt_version",
+        )
+    except (requests.RequestException, RuntimeError) as e:
+        logger.warning("weekly_ai_advice cache write skipped: %s", e)
+
+
+# --------------------------------------------------------------------------
+# 프롬프트 조립
+# --------------------------------------------------------------------------
 
 _DIET_LABEL: dict[str, str] = {
     "normal": "식단 정상",
@@ -180,11 +330,54 @@ def _build_user_content(
         f"대결 기간: {start_date} ~ {end_date}\n\n"
         f"주간 기록:\n{logs_summary}\n\n"
         f"{extra_context}\n"
-        "위 데이터를 바탕으로 맞춤 조언을 해주세요."
+        "위 데이터를 바탕으로 맞춤 조언을 JSON 스키마에 맞춰 제시하세요."
     )
 
 
-def _call_grok(user_content: str) -> str:
+# --------------------------------------------------------------------------
+# Grok 호출 + JSON 파싱
+# --------------------------------------------------------------------------
+
+def _parse_advice_json(raw: str) -> dict[str, Any]:
+    """Grok 응답 문자열 → {summary, action_items[], cautions[]} 로 정규화.
+    JSON 파싱 실패 시 평문을 summary 로 폴백."""
+    try:
+        data = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return {"summary": raw.strip(), "action_items": [], "cautions": []}
+    if not isinstance(data, dict):
+        return {"summary": raw.strip(), "action_items": [], "cautions": []}
+
+    def _str_list(value: Any) -> list[str]:
+        if not isinstance(value, list):
+            return []
+        return [str(x).strip() for x in value if str(x).strip()]
+
+    summary = str(data.get("summary") or "").strip()
+    action_items = _str_list(data.get("action_items"))
+    cautions = _str_list(data.get("cautions"))
+    if not summary and not action_items:
+        return {"summary": raw.strip(), "action_items": [], "cautions": []}
+    return {"summary": summary, "action_items": action_items, "cautions": cautions}
+
+
+def _build_advice_md(structured: dict[str, Any]) -> str:
+    """구조화 응답 → 사람이 읽는 평문 (구버전 클라이언트 호환·폴백 표시용)."""
+    parts: list[str] = []
+    summary = structured.get("summary", "")
+    if summary:
+        parts.append(summary)
+    items = structured.get("action_items") or []
+    if items:
+        parts.append("[이번 주 실천]\n" + "\n".join(f"- {x}" for x in items))
+    cautions = structured.get("cautions") or []
+    if cautions:
+        parts.append("[주의]\n" + "\n".join(f"- {x}" for x in cautions))
+    return "\n\n".join(parts).strip()
+
+
+def _call_grok(user_content: str) -> dict[str, Any]:
+    """Grok 호출 → 구조화 dict 반환."""
     api_key = os.environ.get("XAI_API_KEY")
     if not api_key:
         raise RuntimeError("XAI_API_KEY not configured")
@@ -197,6 +390,7 @@ def _call_grok(user_content: str) -> str:
         ],
         "max_tokens": XAI_MAX_TOKENS,
         "temperature": 0.7,
+        "response_format": {"type": "json_object"},
     }
     headers = {
         "Authorization": f"Bearer {api_key}",
@@ -214,8 +408,32 @@ def _call_grok(user_content: str) -> str:
     content = (message.get("content") or "").strip()
     if not content:
         raise RuntimeError("Grok response content was empty")
-    return content
+    return _parse_advice_json(content)
 
+
+def _advice_payload(
+    structured: dict[str, Any],
+    advice_md: str,
+    week_no: int,
+    cached: bool,
+    model: str | None,
+) -> dict[str, Any]:
+    return {
+        # 구버전 클라이언트 호환: 평문 advice 필드는 항상 유지.
+        "advice": advice_md,
+        "summary": structured.get("summary", ""),
+        "action_items": structured.get("action_items", []),
+        "cautions": structured.get("cautions", []),
+        "cached": cached,
+        "week_no": week_no,
+        "model": model,
+        "prompt_version": PROMPT_VERSION,
+    }
+
+
+# --------------------------------------------------------------------------
+# 엔드포인트
+# --------------------------------------------------------------------------
 
 @bp.route("/ai/advice", methods=["POST", "OPTIONS"])
 def ai_advice():
@@ -224,14 +442,24 @@ def ai_advice():
 
     body = request.get_json(silent=True) or {}
     participant_id = body.get("participant_id")
-    user_context = str(body.get("user_context") or "").strip()
-    advice_style = str(body.get("advice_style") or "").strip()
-    advice_goal = str(body.get("advice_goal") or "").strip()
     if not participant_id:
         return jsonify({"error": "participant_id required"}), 400
+    participant_id = str(participant_id)
+
+    force_refresh = bool(body.get("force_refresh"))
+
+    # 입력 가드 — 길이 제한 + 화이트리스트
+    user_context = str(body.get("user_context") or "").strip()[:USER_CONTEXT_MAX_CHARS]
+    advice_style = str(body.get("advice_style") or "").strip()
+    if advice_style and advice_style not in ADVICE_STYLE_WHITELIST:
+        advice_style = ""
+    advice_goal = str(body.get("advice_goal") or "").strip()
+    if advice_goal and advice_goal not in ADVICE_GOAL_WHITELIST:
+        advice_goal = ""
+    has_user_input = bool(user_context or advice_style or advice_goal)
 
     try:
-        participant = _fetch_participant(str(participant_id))
+        participant = _fetch_participant(participant_id)
     except RuntimeError as e:
         logger.error("Supabase config error: %s", e)
         return jsonify({"error": "Supabase not configured"}), 500
@@ -243,11 +471,36 @@ def ai_advice():
         return jsonify({"error": "Participant not found"}), 404
 
     try:
-        logs = _fetch_weekly_logs(str(participant_id))
+        logs = _fetch_weekly_logs(participant_id)
         start_date, end_date = _fetch_challenge_dates(participant.get("challenge_id"))
     except requests.RequestException as e:
         logger.exception("Supabase fetch (logs/challenge) failed: %s", e)
         return jsonify({"error": "Failed to fetch supporting data"}), 502
+
+    week_no = _compute_week_no(start_date)
+
+    # 캐시 조회 — 사용자 추가 입력이 없고 강제 새로고침이 아닐 때만.
+    if not force_refresh and not has_user_input:
+        cached = _fetch_cached_advice(participant_id, week_no)
+        if cached:
+            cached_json = cached.get("advice_json")
+            structured = (
+                cached_json
+                if isinstance(cached_json, dict)
+                else _parse_advice_json(str(cached.get("advice_md") or ""))
+            )
+            return (
+                jsonify(
+                    _advice_payload(
+                        structured,
+                        str(cached.get("advice_md") or _build_advice_md(structured)),
+                        week_no,
+                        cached=True,
+                        model=cached.get("model"),
+                    )
+                ),
+                200,
+            )
 
     user_content = _build_user_content(
         participant,
@@ -260,7 +513,7 @@ def ai_advice():
     )
 
     try:
-        advice = _call_grok(user_content)
+        structured = _call_grok(user_content)
     except RuntimeError as e:
         logger.error("Grok config/runtime error: %s", e)
         return jsonify({"error": "AI service not configured"}), 500
@@ -268,7 +521,14 @@ def ai_advice():
         logger.exception("Grok call failed: %s", e)
         return jsonify({"error": "AI service unavailable"}), 502
 
-    return jsonify({"advice": advice}), 200
+    advice_md = _build_advice_md(structured)
+
+    # 사용자 추가 입력이 있는 응답은 *개인 맞춤* 이므로 공용 캐시에 저장하지 않는다.
+    # (캐시는 항상 일반 조언만 담아 다른 친구가 열었을 때 일관되게.)
+    if not has_user_input:
+        _store_advice(participant_id, week_no, advice_md, structured)
+
+    return jsonify(_advice_payload(structured, advice_md, week_no, cached=False, model=XAI_MODEL)), 200
 
 
 @bp.route("/ai/health", methods=["GET"])
@@ -279,6 +539,7 @@ def ai_health():
         "supabase_configured": bool(supabase_url and supabase_key),
         "xai_configured": bool(os.environ.get("XAI_API_KEY")),
         "model": XAI_MODEL,
+        "prompt_version": PROMPT_VERSION,
     }), 200
 
 
@@ -289,7 +550,6 @@ def ai_debug():
     if not supabase_url or not supabase_key:
         return jsonify({"ok": False, "error": "Supabase env vars not set"}), 500
 
-    # 실제 REST 요청 (participants 1건만)
     headers = {
         "apikey": supabase_key,
         "Authorization": f"Bearer {supabase_key}",
@@ -302,9 +562,18 @@ def ai_debug():
             headers=headers,
             timeout=10,
         )
+        # weekly_ai_advice 캐시 테이블 존재 여부도 함께 확인.
+        cache_resp = requests.get(
+            f"{supabase_url}/rest/v1/weekly_ai_advice",
+            params={"select": "id", "limit": "1"},
+            headers=headers,
+            timeout=10,
+        )
         return jsonify({
             "ok": resp.ok,
             "supabase_status": resp.status_code,
+            "weekly_ai_advice_status": cache_resp.status_code,
+            "weekly_ai_advice_ready": cache_resp.ok,
             "supabase_url_host": supabase_url.split("//")[-1].split(".")[0] + ".supabase.co (masked)",
             "supabase_body_preview": (resp.text or "")[:300],
         }), 200

--- a/burnfat/docs/IMPROVEMENT_REPORT_2026-05.md
+++ b/burnfat/docs/IMPROVEMENT_REPORT_2026-05.md
@@ -281,7 +281,7 @@ HomePage(코드 입력) → ChallengePage(/c/:code)
 
 ---
 
-### Sprint 2 — 4~5주차 (제품 가치 확장)
+### Sprint 2 — 4~5주차 (제품 가치 확장) ✅ **완료 (2026-05-15, [`SPRINT2_HANDOFF.md`](SPRINT2_HANDOFF.md))**
 
 1. **AI 조언 서버 캐시 + JSON 응답** (3~5일)
    - 신규 테이블 `weekly_ai_advice`. 동일 (participant, week_no) 캐시 hit률 80%+ 기대.

--- a/burnfat/docs/SPRINT2_HANDOFF.md
+++ b/burnfat/docs/SPRINT2_HANDOFF.md
@@ -1,0 +1,154 @@
+# Sprint 2 핸드오프 — 제품 가치 확장
+
+> **상태**: ✅ 코드 완료 / ⏳ 배포 대기 (마이그레이션 + 백엔드 배포 필요 — §4)
+> **날짜**: 2026-05-15
+> **선행 Sprint**: [`SPRINT1_HANDOFF.md`](SPRINT1_HANDOFF.md)
+> **로드맵**: [`IMPROVEMENT_REPORT_2026-05.md`](IMPROVEMENT_REPORT_2026-05.md) §6 Sprint 2
+
+---
+
+## 1. 목표
+
+제품 가치 확장 3종. **Sprint 0 이후 처음으로 백엔드·DB 변경을 포함**한다
+(AI 캐시). 배포 순서에 무관하도록 모든 신규 경로를 graceful degrade 처리.
+
+---
+
+## 2. 적용된 변경
+
+### 2.1 AI 조언 서버 캐시 + JSON 구조화 응답
+
+- **신규 마이그레이션** [`20260515000001_weekly_ai_advice.sql`](../supabase/migrations/20260515000001_weekly_ai_advice.sql)
+  — `weekly_ai_advice(participant_id, week_no, prompt_version, advice_md, advice_json, model, …)`.
+  `UNIQUE(participant_id, week_no, prompt_version)`. RLS ON + anon 정책 없음 → anon 전면 deny,
+  백엔드(service_role)만 접근.
+- **백엔드** [`backend/routes/burnfat_ai.py`](../../backend/routes/burnfat_ai.py) 재작성:
+  - Grok 응답을 단일 문자열 → **JSON 구조화**(`{summary, action_items[], cautions[]}`).
+    `response_format: json_object` + 시스템 프롬프트 스키마 강제. 파싱 실패 시 평문 폴백.
+  - **서버 캐시**: `(participant_id, week_no, prompt_version)` 키로 read-through + upsert.
+    신선도는 `updated_at` 기준 24h TTL. `force_refresh` / 사용자 추가 입력 시 캐시 우회.
+    사용자 추가 입력(개인 맞춤) 응답은 공용 캐시에 저장하지 않음.
+  - `week_no` 는 챌린지 `start_date` 기준 서버 계산.
+  - **graceful degrade**: 캐시 테이블이 없거나(마이그레이션 미적용) 일시 오류여도 조언 생성은
+    그대로 동작 (캐시 read/write 를 try/except 로 감쌈).
+  - **입력 가드**: `user_context` 500자 컷, `advice_style`/`advice_goal` 화이트리스트.
+  - 응답에 `advice`(평문) 필드 유지 → 구버전 클라이언트 호환.
+- **프론트엔드**:
+  - [`edgeFunctions.ts`](../src/lib/edgeFunctions.ts) — `AIAdviceResponse` 에 `structured`/`cached`/
+    `weekNo` 추가. 구버전 백엔드(구조화 필드 없음)면 `structured=null` → 평문 폴백.
+  - [`useAIAdvice.ts`](../src/hooks/useAIAdvice.ts) — **localStorage 디바이스 캐시 제거**
+    (서버 캐시가 대체, "공동 모니터링" 콘셉트와 일치). `result` 객체 반환.
+  - [`AIAdviceCard.tsx`](../src/components/AIAdviceCard.tsx) — `summary` / 이번 주 실천 /
+    주의 섹션 분할 렌더(`StructuredAdviceView`). 평문 폴백 유지. 캐시 hit 캡션.
+
+### 2.2 목표 체지방률 진행률 위젯
+
+- **신규** [`src/lib/goalProgress.ts`](../src/lib/goalProgress.ts) — 순수 함수
+  `computeGoalProgress(start, current, target)` → 진행률 0~100 + 도달 여부 + 남은 %p.
+- **신규** [`src/components/GoalProgressWidget.tsx`](../src/components/GoalProgressWidget.tsx)
+  — 시작/현재/목표 3점 게이지(`LinearProgress` + a11y). 목표 미설정 시 빈 상태 + 설정 버튼.
+- `ChallengePage` Tab 2 상단에 식별된 "나"(Sprint 1 `myParticipant`)에 대해 고정 노출.
+
+### 2.3 챌린지 생성 템플릿
+
+- **신규** [`src/lib/challengeTemplates.ts`](../src/lib/challengeTemplates.ts) — 4/8/12주
+  프리셋(참가비 5만/10만/20만) + `templateEndDate(start, weeks)` 순수 함수(UTC 결정적).
+- **신규** [`src/components/ChallengeTemplatePicker.tsx`](../src/components/ChallengeTemplatePicker.tsx)
+  — 프리셋 카드 3종(`CardActionArea` + `aria-pressed`).
+- [`CreateChallengePage.tsx`](../src/pages/CreateChallengePage.tsx) — 폼 상단에 picker.
+  선택 시 종료일·참가비 자동 채움. 시작일 변경 시 종료일 재계산. 값 직접 수정 시 선택 해제.
+
+---
+
+## 3. 검증
+
+- `npx tsc --noEmit` — 클린.
+- `npm run build` — 성공 (번들 1,116 kB).
+- `npm test` — **44/44 통과** (goalProgress 8 + challengeTemplates 7 + challengeSchedule 11 +
+  prizeDistribution 6 + useNextRecordableWeek 12).
+- `python3 -m py_compile backend/routes/burnfat_ai.py` — 클린.
+
+---
+
+## 4. 배포 절차 (운영자 수행 — 중요)
+
+Sprint 2 는 **DB + 백엔드 변경을 포함**한다. 권장 순서:
+
+### 4.1 마이그레이션 적용 (Supabase SQL Editor)
+
+`burnfat/supabase/migrations/20260515000001_weekly_ai_advice.sql` 전체를 SQL Editor 에 붙여
+실행. 검증:
+
+```sql
+-- 테이블 + RLS 확인
+SELECT tablename, rowsecurity FROM pg_tables WHERE tablename = 'weekly_ai_advice';
+-- → weekly_ai_advice | true
+
+-- anon 정책이 없어야 함 (백엔드 service_role 만 접근)
+SELECT policyname FROM pg_policies WHERE tablename = 'weekly_ai_advice';
+-- → 0 rows
+```
+
+### 4.2 백엔드 배포 (Railway)
+
+`backend/routes/burnfat_ai.py` 변경이 포함된 커밋을 Railway 가 자동 배포. 배포 후:
+
+```
+GET https://wodybody-production.up.railway.app/api/burnfat/ai/debug
+→ "weekly_ai_advice_ready": true  (마이그레이션 적용됐으면)
+GET .../api/burnfat/ai/health
+→ "prompt_version": "sprint2-json-v1"
+```
+
+### 4.3 프론트엔드 배포 (Vercel)
+
+main 머지 시 자동 배포.
+
+### 4.4 배포 순서 무관성 (안전망)
+
+- **마이그레이션 < 백엔드**: 캐시 read/write 가 try/except 로 감싸여 테이블이 없어도 조언은 동작
+  (캐시만 미적용). 마이그레이션을 나중에 적용해도 안전.
+- **백엔드 < 프론트 또는 프론트 < 백엔드**: 백엔드는 항상 `advice` 평문을 반환하고,
+  프론트는 구조화 필드가 없으면 평문 폴백 → 어느 쪽이 먼저 배포돼도 깨지지 않음.
+
+---
+
+## 5. 알려진 잔여 위험 / 후속 처리
+
+- **캐시 무효화는 24h TTL + week_no 키 + 강제 새로고침**만으로 처리. weekly_logs INSERT/UPDATE
+  시 같은 주차 캐시를 *즉시* 무효화하는 DB 트리거는 **Sprint 2.5 (§2.5.1)** 범위 — 그때 도입.
+  현재는 주중에 기록을 추가해도 24h 안에는 캐시된 조언이 나올 수 있음("새로 받기"로 우회 가능).
+- **JSON 응답 강제**: `response_format: json_object` 미지원 모델로 `XAI_MODEL` 을 바꾸면 파싱
+  폴백이 평문을 `summary` 로 넣는다 — 동작은 유지되나 섹션 분할이 안 됨. 현재 기본 모델은 지원.
+- **공용 캐시 vs 개인 맥락**: 사용자 추가 입력 응답은 캐시에 저장하지 않으므로 친구가 보는
+  캐시는 항상 일반 조언. 의도된 동작 (Sprint 2.5 코치 세션이 개인 맥락 영속화 담당).
+- **목표 진행률 위젯은 식별된 "나"에게만** 노출 (Sprint 1 localStorage 식별 의존). 미식별
+  사용자는 위젯이 안 보임 — 참가자별 카드에 분산 노출은 향후 검토.
+- **번들 크기** 1,116 kB — 청크 분할은 Sprint 3.
+- **테스트**: 순수 lib 함수만 vitest. 백엔드 Python 은 이 레포에 pytest 인프라가 없어 미검증
+  (`py_compile` 만). 컴포넌트는 Sprint 3 jsdom 도입 시.
+
+---
+
+## 6. 다음 단계
+
+1. **Sprint 2.5 — 대화형 코치 모달**. `weekly_ai_advice` 캐시·JSON 스키마·서버 피처
+   엔지니어링이 본 Sprint 로 깔렸으므로 자연스럽게 이어짐. 신규 마이그레이션
+   `coach_sessions`/`coach_messages`/`participant_coach_memory`, `burnfat_coach.py`, SSE 스트리밍.
+2. **Sprint 3 — ChallengePage 분해 / N+1 제거 / 테스트 베이스라인**.
+
+각 Sprint DoD 는 `IMPROVEMENT_REPORT_2026-05.md` 해당 섹션 기준.
+
+---
+
+## 7. 빠른 롤백 가이드
+
+- **프론트엔드**: Vercel Deployments → Sprint 2 직전 빌드(Sprint 1 커밋 `c3d61a6`) Promote.
+- **백엔드**: Railway 에서 직전 배포로 롤백 → 구버전 `burnfat_ai.py`(평문 응답) 복귀. 프론트가
+  구버전 백엔드여도 평문 폴백하므로 프론트 롤백 없이 백엔드만 롤백해도 안전.
+- **DB**: `weekly_ai_advice` 는 *추가 전용* 테이블이라 롤백 불요. 정 제거하려면
+  `DROP TABLE weekly_ai_advice;` (다른 테이블 의존 없음). 캐시 데이터만 사라지며 기능 영향 없음.
+- **부분 비활성**: 목표 위젯/템플릿은 순수 클라이언트 — `ChallengePage`/`CreateChallengePage`
+  에서 해당 컴포넌트 렌더 줄만 주석 처리하면 격리 제거.
+
+— 끝 —

--- a/burnfat/src/components/AIAdviceCard.tsx
+++ b/burnfat/src/components/AIAdviceCard.tsx
@@ -20,7 +20,10 @@ import PsychologyIcon from '@mui/icons-material/Psychology';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import RadioButtonUncheckedIcon from '@mui/icons-material/RadioButtonUnchecked';
+import TaskAltIcon from '@mui/icons-material/TaskAlt';
+import WarningAmberIcon from '@mui/icons-material/WarningAmber';
 import { useAIAdvice } from '../hooks/useAIAdvice';
+import type { StructuredAdvice } from '../lib/edgeFunctions';
 import type { ParticipantWithSubmissions, WeeklyLog } from '../types';
 
 interface Props {
@@ -45,8 +48,51 @@ const ADVICE_STYLES = [
   { value: '운동 중심으로', label: '운동 중심으로' },
 ];
 
+/** Sprint 2: 구조화 조언 섹션 (summary / 이번 주 실천 / 주의). */
+function StructuredAdviceView({ structured }: { structured: StructuredAdvice }) {
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.25, mb: 1 }}>
+      {structured.summary && (
+        <Typography variant="body2" fontWeight={600}>
+          {structured.summary}
+        </Typography>
+      )}
+      {structured.actionItems.length > 0 && (
+        <Box>
+          <Typography variant="caption" fontWeight={700} color="primary.dark" sx={{ display: 'block', mb: 0.5 }}>
+            이번 주 실천
+          </Typography>
+          <Box component="ul" sx={{ listStyle: 'none', m: 0, p: 0, display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+            {structured.actionItems.map((item, i) => (
+              <Box component="li" key={i} sx={{ display: 'flex', alignItems: 'flex-start', gap: 0.75 }}>
+                <TaskAltIcon sx={{ fontSize: 16, color: 'success.main', mt: '2px', flexShrink: 0 }} aria-hidden />
+                <Typography variant="body2">{item}</Typography>
+              </Box>
+            ))}
+          </Box>
+        </Box>
+      )}
+      {structured.cautions.length > 0 && (
+        <Box>
+          <Typography variant="caption" fontWeight={700} color="warning.dark" sx={{ display: 'block', mb: 0.5 }}>
+            주의
+          </Typography>
+          <Box component="ul" sx={{ listStyle: 'none', m: 0, p: 0, display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+            {structured.cautions.map((item, i) => (
+              <Box component="li" key={i} sx={{ display: 'flex', alignItems: 'flex-start', gap: 0.75 }}>
+                <WarningAmberIcon sx={{ fontSize: 16, color: 'warning.main', mt: '2px', flexShrink: 0 }} aria-hidden />
+                <Typography variant="body2">{item}</Typography>
+              </Box>
+            ))}
+          </Box>
+        </Box>
+      )}
+    </Box>
+  );
+}
+
 export default function AIAdviceCard({ participant, logs, onOpenBasicInfo, onOpenLogForm }: Props) {
-  const { advice, loading, error, isCached, load, reset } = useAIAdvice();
+  const { result, loading, error, load, reset } = useAIAdvice();
   const [requested, setRequested] = useState(false);
   const [contextDialogOpen, setContextDialogOpen] = useState(false);
   const [userContext, setUserContext] = useState('');
@@ -156,14 +202,18 @@ export default function AIAdviceCard({ participant, logs, onOpenBasicInfo, onOpe
             {error}
           </Typography>
         )}
-        {advice && !loading && (
+        {result && !loading && (
           <>
-            <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap', mb: 1 }}>
-              {advice}
-            </Typography>
-            {isCached && (
-              <Typography variant="caption" color="text.disabled">
-                오늘 캐시된 조언 · 새로 받으려면 아래 버튼을 누르세요
+            {result.structured ? (
+              <StructuredAdviceView structured={result.structured} />
+            ) : (
+              <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap', mb: 1 }}>
+                {result.advice}
+              </Typography>
+            )}
+            {result.cached && (
+              <Typography variant="caption" color="text.disabled" display="block">
+                공동 캐시된 조언{result.weekNo != null ? ` · ${result.weekNo}주차` : ''} · 새로 받으려면 아래 버튼을 누르세요
               </Typography>
             )}
           </>
@@ -195,7 +245,7 @@ export default function AIAdviceCard({ participant, logs, onOpenBasicInfo, onOpe
             )}
           </>
         )}
-        {requested && !loading && advice && (
+        {requested && !loading && result && (
           <Button
             size="small"
             variant="outlined"
@@ -241,7 +291,8 @@ export default function AIAdviceCard({ participant, logs, onOpenBasicInfo, onOpe
             label="현재 상황/고민"
             placeholder="예: 이번 주 회식이 2번 있었고 수면이 부족했어요. 운동은 2번밖에 못 했고 체중은 그대로입니다."
             value={userContext}
-            onChange={(e) => setUserContext(e.target.value)}
+            onChange={(e) => setUserContext(e.target.value.slice(0, 500))}
+            helperText={`${userContext.length}/500자`}
           />
         </DialogContent>
         <DialogActions sx={{ px: 3, pb: 2 }}>

--- a/burnfat/src/components/ChallengeTemplatePicker.tsx
+++ b/burnfat/src/components/ChallengeTemplatePicker.tsx
@@ -1,0 +1,65 @@
+import Box from '@mui/material/Box';
+import Card from '@mui/material/Card';
+import CardActionArea from '@mui/material/CardActionArea';
+import Typography from '@mui/material/Typography';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import { CHALLENGE_TEMPLATES, type ChallengeTemplate } from '../lib/challengeTemplates';
+
+interface Props {
+  /** 선택된 템플릿 id. 사용자가 값을 직접 수정하면 null(=직접 설정). */
+  selectedId: string | null;
+  onSelect: (template: ChallengeTemplate) => void;
+}
+
+/**
+ * Sprint 2 — 챌린지 생성 템플릿 선택.
+ * 4/8/12주 프리셋 카드. 선택 시 종료일·참가비를 자동 채운다.
+ */
+export default function ChallengeTemplatePicker({ selectedId, onSelect }: Props) {
+  return (
+    <Box sx={{ mb: 2 }}>
+      <Typography variant="subtitle2" color="text.secondary" gutterBottom>
+        템플릿으로 빠르게 시작
+      </Typography>
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+        {CHALLENGE_TEMPLATES.map((t) => {
+          const selected = t.id === selectedId;
+          return (
+            <Card
+              key={t.id}
+              variant="outlined"
+              sx={{
+                borderColor: selected ? 'primary.main' : 'grey.300',
+                borderWidth: selected ? 2 : 1,
+                bgcolor: selected ? 'primary.50' : 'background.paper',
+              }}
+            >
+              <CardActionArea
+                onClick={() => onSelect(t)}
+                aria-pressed={selected}
+                aria-label={`${t.label} — 참가비 ${t.stakeAmount.toLocaleString('ko-KR')}원`}
+                sx={{ p: 1.5, display: 'flex', alignItems: 'center', gap: 1 }}
+              >
+                <Box sx={{ flex: 1, minWidth: 0 }}>
+                  <Typography variant="subtitle2" fontWeight={700}>
+                    {t.label}
+                  </Typography>
+                  <Typography variant="caption" color="text.secondary" display="block">
+                    {t.description}
+                  </Typography>
+                  <Typography variant="caption" color="primary.dark" fontWeight={600}>
+                    {t.weeks}주 · 참가비 {t.stakeAmount.toLocaleString('ko-KR')}원
+                  </Typography>
+                </Box>
+                {selected && <CheckCircleIcon color="primary" sx={{ fontSize: 22 }} aria-hidden />}
+              </CardActionArea>
+            </Card>
+          );
+        })}
+      </Box>
+      <Typography variant="caption" color="text.disabled" sx={{ display: 'block', mt: 0.75 }}>
+        선택 후 아래에서 자유롭게 수정할 수 있어요.
+      </Typography>
+    </Box>
+  );
+}

--- a/burnfat/src/components/GoalProgressWidget.tsx
+++ b/burnfat/src/components/GoalProgressWidget.tsx
@@ -1,0 +1,133 @@
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Typography from '@mui/material/Typography';
+import LinearProgress from '@mui/material/LinearProgress';
+import FlagIcon from '@mui/icons-material/Flag';
+import EmojiEventsIcon from '@mui/icons-material/EmojiEvents';
+import type { ParticipantWithSubmissions, WeeklyLog } from '../types';
+import { computeGoalProgress } from '../lib/goalProgress';
+
+interface Props {
+  participant: ParticipantWithSubmissions;
+  logs: WeeklyLog[];
+  onOpenBasicInfo: () => void;
+}
+
+interface StatProps {
+  label: string;
+  value: number | null;
+  emphasize?: boolean;
+}
+
+function Stat({ label, value, emphasize }: StatProps) {
+  return (
+    <Box sx={{ textAlign: 'center', flex: 1 }}>
+      <Typography variant="caption" color="text.secondary" display="block">
+        {label}
+      </Typography>
+      <Typography variant="subtitle1" fontWeight={emphasize ? 800 : 600} color={emphasize ? 'primary.main' : 'text.primary'}>
+        {value != null ? `${value}%` : '-'}
+      </Typography>
+    </Box>
+  );
+}
+
+/**
+ * Sprint 2 — 목표 체지방률 진행률 위젯.
+ * 시작 인증값 → 최신 주간 기록 → 목표값의 3점으로 진행률 게이지를 그린다.
+ * 식별된 "나" 에 대해 주간 기록 탭 상단에 고정 노출.
+ */
+export default function GoalProgressWidget({ participant, logs, onOpenBasicInfo }: Props) {
+  const startBodyFat = participant.submissions.find((s) => s.type === 'start')?.body_fat_rate ?? null;
+  const endBodyFat = participant.submissions.find((s) => s.type === 'end')?.body_fat_rate ?? null;
+  // 현재값 — 최신 주간 기록 우선, 없으면 종료 인증값.
+  const latestLog = [...logs]
+    .filter((l) => l.body_fat_rate != null)
+    .sort((a, b) => b.week_no - a.week_no)[0];
+  const currentBodyFat = latestLog?.body_fat_rate ?? endBodyFat ?? null;
+  const target = participant.target_body_fat;
+
+  const progress = computeGoalProgress(startBodyFat, currentBodyFat, target);
+
+  // 빈 상태 — 목표 미설정
+  if (!progress.hasGoal) {
+    return (
+      <Card sx={{ mb: 2, border: '1px dashed', borderColor: 'grey.300' }}>
+        <CardContent sx={{ p: 2 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.5 }}>
+            <FlagIcon sx={{ fontSize: 20, color: 'text.disabled' }} aria-hidden />
+            <Typography variant="subtitle2" color="text.secondary">
+              목표 진행률
+            </Typography>
+          </Box>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+            {startBodyFat == null
+              ? '시작 인증과 목표 체지방률을 설정하면 진행률을 볼 수 있어요.'
+              : '목표 체지방률을 설정하면 시작값 대비 진행률을 볼 수 있어요.'}
+          </Typography>
+          <Button size="small" variant="outlined" onClick={onOpenBasicInfo}>
+            목표 체지방률 설정
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const noCurrent = progress.currentBodyFat == null;
+
+  return (
+    <Card sx={{ mb: 2, border: '1px solid', borderColor: progress.reached ? 'success.200' : 'primary.200', bgcolor: progress.reached ? 'success.50' : 'primary.50' }}>
+      <CardContent sx={{ p: 2 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1.5 }}>
+          {progress.reached ? (
+            <EmojiEventsIcon sx={{ fontSize: 20, color: 'success.main' }} aria-hidden />
+          ) : (
+            <FlagIcon sx={{ fontSize: 20, color: 'primary.main' }} aria-hidden />
+          )}
+          <Typography variant="subtitle2" color={progress.reached ? 'success.dark' : 'primary.dark'} sx={{ flex: 1 }}>
+            {participant.nickname}님 목표 진행률
+          </Typography>
+          <Typography variant="subtitle2" fontWeight={800} color={progress.reached ? 'success.main' : 'primary.main'}>
+            {progress.progressPct}%
+          </Typography>
+        </Box>
+
+        <Box sx={{ display: 'flex', gap: 1, mb: 1 }}>
+          <Stat label="시작" value={progress.startBodyFat} />
+          <Stat label="현재" value={progress.currentBodyFat} emphasize />
+          <Stat label="목표" value={progress.targetBodyFat} />
+        </Box>
+
+        <LinearProgress
+          variant="determinate"
+          value={progress.progressPct}
+          color={progress.reached ? 'success' : 'primary'}
+          aria-label="목표 진행률"
+          aria-valuenow={progress.progressPct}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          sx={{ height: 10, borderRadius: 5, mb: 1 }}
+        />
+
+        {progress.reached ? (
+          <Typography variant="body2" color="success.dark" fontWeight={600}>
+            🎉 목표 체지방률을 달성했어요!
+          </Typography>
+        ) : noCurrent ? (
+          <Typography variant="caption" color="text.secondary">
+            아직 현재 기록이 없어요. 주간 기록을 입력하면 진행률이 채워집니다.
+          </Typography>
+        ) : (
+          <Typography variant="body2" color="text.secondary">
+            목표까지 <strong>{progress.remainingToTarget}%p</strong> 남았어요
+            {progress.deltaFromStart != null && progress.deltaFromStart < 0
+              ? ` · 시작 대비 ${Math.abs(progress.deltaFromStart)}%p 감량`
+              : ''}
+          </Typography>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/burnfat/src/hooks/useAIAdvice.ts
+++ b/burnfat/src/hooks/useAIAdvice.ts
@@ -1,79 +1,42 @@
 import { useState, useCallback } from 'react';
-import { fetchAIAdvice, type AIAdviceRequest } from '../lib/edgeFunctions';
+import { fetchAIAdvice, type AIAdviceRequest, type AIAdviceResponse } from '../lib/edgeFunctions';
 
-const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24시간
-
-function cacheKey(participantId: string) {
-  return `bf_ai_${participantId}`;
-}
-
-function readCache(participantId: string): string | null {
-  try {
-    const raw = localStorage.getItem(cacheKey(participantId));
-    if (!raw) return null;
-    const { advice, cachedAt } = JSON.parse(raw) as { advice: string; cachedAt: number };
-    if (Date.now() - cachedAt > CACHE_TTL_MS) {
-      localStorage.removeItem(cacheKey(participantId));
-      return null;
-    }
-    return advice;
-  } catch {
-    return null;
-  }
-}
-
-function writeCache(participantId: string, advice: string) {
-  try {
-    localStorage.setItem(cacheKey(participantId), JSON.stringify({ advice, cachedAt: Date.now() }));
-  } catch { /* 저장 공간 부족 등 무시 */ }
-}
-
-export function clearAIAdviceCache(participantId: string) {
-  try { localStorage.removeItem(cacheKey(participantId)); } catch { /* ignore */ }
-}
-
+/**
+ * Sprint 2: 디바이스 단위 localStorage 캐시 제거.
+ *   - 캐시는 이제 서버(weekly_ai_advice 테이블)가 담당 → 같은 챌린지의 다른 친구가 열어도
+ *     Grok 재호출 없이 캐시 hit ("공동 모니터링" 콘셉트와 일치).
+ *   - `result.cached` 가 서버 캐시 hit 여부를 알려 준다.
+ */
 export function useAIAdvice() {
-  const [advice, setAdvice] = useState<string | null>(null);
+  const [result, setResult] = useState<AIAdviceResponse | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [isCached, setIsCached] = useState(false);
 
-  const load = useCallback(async (
-    participantId: string,
-    forceRefresh = false,
-    options?: Omit<AIAdviceRequest, 'participantId'>
-  ) => {
-    if (!forceRefresh) {
-      const cached = readCache(participantId);
-      if (cached) {
-        setAdvice(cached);
-        setIsCached(true);
-        setError(null);
+  const load = useCallback(
+    async (
+      participantId: string,
+      forceRefresh = false,
+      options?: Omit<AIAdviceRequest, 'participantId' | 'forceRefresh'>
+    ) => {
+      setLoading(true);
+      setError(null);
+      setResult(null);
+      try {
+        const res = await fetchAIAdvice({ participantId, forceRefresh, ...options });
+        setResult(res);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'AI 조언을 불러올 수 없습니다.');
+      } finally {
         setLoading(false);
-        return;
       }
-    }
-    setLoading(true);
-    setError(null);
-    setAdvice(null);
-    setIsCached(false);
-    try {
-      const res = await fetchAIAdvice({ participantId, ...options });
-      setAdvice(res.advice);
-      setIsCached(false);
-      writeCache(participantId, res.advice);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : 'AI 조언을 불러올 수 없습니다.');
-    } finally {
-      setLoading(false);
-    }
-  }, []);
+    },
+    []
+  );
 
   const reset = useCallback(() => {
-    setAdvice(null);
+    setResult(null);
     setError(null);
-    setIsCached(false);
   }, []);
 
-  return { advice, loading, error, isCached, load, reset };
+  return { result, loading, error, load, reset };
 }

--- a/burnfat/src/lib/challengeTemplates.test.ts
+++ b/burnfat/src/lib/challengeTemplates.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { CHALLENGE_TEMPLATES, templateEndDate } from './challengeTemplates';
+
+describe('CHALLENGE_TEMPLATES', () => {
+  it('4/8/12주 프리셋 3종 — 참가비 5만/10만/20만', () => {
+    expect(CHALLENGE_TEMPLATES).toHaveLength(3);
+    expect(CHALLENGE_TEMPLATES.map((t) => t.weeks)).toEqual([4, 8, 12]);
+    expect(CHALLENGE_TEMPLATES.map((t) => t.stakeAmount)).toEqual([50000, 100000, 200000]);
+  });
+
+  it('id 는 고유', () => {
+    const ids = CHALLENGE_TEMPLATES.map((t) => t.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describe('templateEndDate', () => {
+  it('4주 = 시작일 + 28일', () => {
+    expect(templateEndDate('2026-05-04', 4)).toBe('2026-06-01');
+  });
+
+  it('8주 = 시작일 + 56일', () => {
+    expect(templateEndDate('2026-05-04', 8)).toBe('2026-06-29');
+  });
+
+  it('12주 = 시작일 + 84일', () => {
+    expect(templateEndDate('2026-01-01', 12)).toBe('2026-03-26');
+  });
+
+  it('월·연 경계를 넘어도 정확', () => {
+    expect(templateEndDate('2026-12-20', 4)).toBe('2027-01-17');
+  });
+
+  it('잘못된 날짜 문자열은 그대로 반환', () => {
+    expect(templateEndDate('', 4)).toBe('');
+    expect(templateEndDate('not-a-date', 4)).toBe('not-a-date');
+  });
+});

--- a/burnfat/src/lib/challengeTemplates.ts
+++ b/burnfat/src/lib/challengeTemplates.ts
@@ -1,0 +1,56 @@
+/**
+ * Sprint 2 — 챌린지 생성 템플릿(프리셋).
+ *
+ * 재참여 사용자의 생성 마찰을 줄이기 위해 기간·참가비 조합을 프리셋으로 제공한다.
+ * 순수 데이터 + 순수 함수.
+ */
+
+export interface ChallengeTemplate {
+  id: string;
+  label: string;
+  /** 챌린지 기간(주). 종료일 계산에 사용. */
+  weeks: number;
+  /** 1인 참가비(원). */
+  stakeAmount: number;
+  /** 카드에 표시할 한 줄 설명. */
+  description: string;
+}
+
+export const CHALLENGE_TEMPLATES: ChallengeTemplate[] = [
+  {
+    id: '4w',
+    label: '4주 챌린지',
+    weeks: 4,
+    stakeAmount: 50000,
+    description: '짧고 굵게 — 한 달 집중 감량',
+  },
+  {
+    id: '8w',
+    label: '8주 챌린지',
+    weeks: 8,
+    stakeAmount: 100000,
+    description: '두 달 — 눈에 띄는 변화',
+  },
+  {
+    id: '12w',
+    label: '12주 챌린지',
+    weeks: 12,
+    stakeAmount: 200000,
+    description: '시즌 단위 — 습관까지 정착',
+  },
+];
+
+/**
+ * 시작일 + 주(week) 수 → 종료일(YYYY-MM-DD).
+ * UTC 기준으로 계산해 타임존에 무관하게 결정적.
+ */
+export function templateEndDate(startDate: string, weeks: number): string {
+  const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(startDate);
+  if (!m) return startDate;
+  const baseMs = Date.UTC(Number(m[1]), Number(m[2]) - 1, Number(m[3]));
+  const end = new Date(baseMs + weeks * 7 * 24 * 60 * 60 * 1000);
+  const y = end.getUTCFullYear();
+  const mo = String(end.getUTCMonth() + 1).padStart(2, '0');
+  const da = String(end.getUTCDate()).padStart(2, '0');
+  return `${y}-${mo}-${da}`;
+}

--- a/burnfat/src/lib/edgeFunctions.ts
+++ b/burnfat/src/lib/edgeFunctions.ts
@@ -10,12 +10,28 @@ function resolveAiAdviceUrl(): string {
   return fromEnv || WODYBODY_GROK_AI_URL;
 }
 
+/** Sprint 2: Grok 구조화 응답 — summary / 실천 항목 / 주의 항목. */
+export interface StructuredAdvice {
+  summary: string;
+  actionItems: string[];
+  cautions: string[];
+}
+
 export interface AIAdviceResponse {
+  /** 평문 조언 — 항상 존재 (구버전 백엔드 호환). */
   advice: string;
+  /** 구조화 조언 — 구버전 백엔드면 null (평문 폴백). */
+  structured: StructuredAdvice | null;
+  /** 서버 캐시에서 반환됐는지. */
+  cached: boolean;
+  /** 조언이 계산된 주차. 구버전 백엔드면 null. */
+  weekNo: number | null;
 }
 
 export interface AIAdviceRequest {
   participantId: string;
+  /** 캐시를 건너뛰고 새로 생성. */
+  forceRefresh?: boolean;
   userContext?: string;
   adviceStyle?: string;
   adviceGoal?: string;
@@ -55,6 +71,11 @@ function parseErrorMessage(res: Response, bodyText: string): string {
   return bodyText?.trim() || `AI 조언 요청 실패 (${res.status})`;
 }
 
+function toStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.map((v) => String(v ?? '').trim()).filter(Boolean);
+}
+
 export async function fetchAIAdvice(req: AIAdviceRequest): Promise<AIAdviceResponse> {
   const url = resolveAiAdviceUrl();
   const res = await fetch(url, {
@@ -62,6 +83,7 @@ export async function fetchAIAdvice(req: AIAdviceRequest): Promise<AIAdviceRespo
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
       participant_id: req.participantId,
+      force_refresh: req.forceRefresh || undefined,
       user_context: req.userContext?.trim() || undefined,
       advice_style: req.adviceStyle || undefined,
       advice_goal: req.adviceGoal || undefined,
@@ -75,12 +97,35 @@ export async function fetchAIAdvice(req: AIAdviceRequest): Promise<AIAdviceRespo
 
   let data: unknown;
   try {
-    data = JSON.parse(text) as AIAdviceResponse;
+    data = JSON.parse(text);
   } catch {
     throw new Error('AI 응답을 해석할 수 없습니다.');
   }
-  if (typeof data === 'object' && data && 'advice' in data && typeof (data as AIAdviceResponse).advice === 'string') {
-    return data as AIAdviceResponse;
+  if (typeof data !== 'object' || data === null) {
+    throw new Error('AI 응답 형식이 올바르지 않습니다.');
   }
-  throw new Error('AI 응답 형식이 올바르지 않습니다.');
+
+  const obj = data as Record<string, unknown>;
+  const advice = typeof obj.advice === 'string' ? obj.advice : '';
+  const summary = typeof obj.summary === 'string' ? obj.summary : '';
+  const actionItems = toStringArray(obj.action_items);
+  const cautions = toStringArray(obj.cautions);
+
+  // 구버전 백엔드는 구조화 필드가 없다 → structured=null, 평문 advice 폴백.
+  const hasStructured = summary !== '' || actionItems.length > 0;
+  const structured: StructuredAdvice | null = hasStructured
+    ? { summary, actionItems, cautions }
+    : null;
+
+  const effectiveAdvice = advice || summary;
+  if (!effectiveAdvice) {
+    throw new Error('AI 응답 형식이 올바르지 않습니다.');
+  }
+
+  return {
+    advice: effectiveAdvice,
+    structured,
+    cached: obj.cached === true,
+    weekNo: typeof obj.week_no === 'number' ? obj.week_no : null,
+  };
 }

--- a/burnfat/src/lib/goalProgress.test.ts
+++ b/burnfat/src/lib/goalProgress.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { computeGoalProgress } from './goalProgress';
+
+describe('computeGoalProgress', () => {
+  it('목표·시작값 없으면 hasGoal=false', () => {
+    expect(computeGoalProgress(null, 25, null).hasGoal).toBe(false);
+    expect(computeGoalProgress(30, 25, null).hasGoal).toBe(false);
+    expect(computeGoalProgress(null, 25, 20).hasGoal).toBe(false);
+  });
+
+  it('시작 30 → 현재 25 → 목표 20 : 진행률 50%', () => {
+    const g = computeGoalProgress(30, 25, 20);
+    expect(g.hasGoal).toBe(true);
+    expect(g.progressPct).toBe(50);
+    expect(g.reached).toBe(false);
+    expect(g.remainingToTarget).toBe(5);
+    expect(g.deltaFromStart).toBe(-5);
+  });
+
+  it('목표 도달 — 현재 ≤ 목표 : 진행률 100, reached', () => {
+    const g = computeGoalProgress(30, 20, 20);
+    expect(g.progressPct).toBe(100);
+    expect(g.reached).toBe(true);
+    expect(g.remainingToTarget).toBe(0);
+  });
+
+  it('목표 초과 달성 — 현재 < 목표 : 100, remaining 음수', () => {
+    const g = computeGoalProgress(30, 18, 20);
+    expect(g.progressPct).toBe(100);
+    expect(g.reached).toBe(true);
+    expect(g.remainingToTarget).toBe(-2);
+  });
+
+  it('시작보다 후퇴 — 현재 > 시작 : 진행률 0', () => {
+    const g = computeGoalProgress(30, 32, 20);
+    expect(g.progressPct).toBe(0);
+    expect(g.deltaFromStart).toBe(2);
+  });
+
+  it('현재값 없으면 시작 지점으로 간주 → 진행률 0', () => {
+    const g = computeGoalProgress(30, null, 20);
+    expect(g.hasGoal).toBe(true);
+    expect(g.progressPct).toBe(0);
+    expect(g.deltaFromStart).toBeNull();
+  });
+
+  it('목표가 시작값 이상(쉬운 목표) — 도달 시 100, 아니면 0', () => {
+    expect(computeGoalProgress(25, 24, 25).progressPct).toBe(100); // 24 ≤ 25
+    expect(computeGoalProgress(25, 26, 25).progressPct).toBe(0); // 26 > 25
+  });
+
+  it('진행률은 0~100 으로 clamp', () => {
+    const g = computeGoalProgress(30, 29, 20);
+    expect(g.progressPct).toBeGreaterThanOrEqual(0);
+    expect(g.progressPct).toBeLessThanOrEqual(100);
+  });
+});

--- a/burnfat/src/lib/goalProgress.ts
+++ b/burnfat/src/lib/goalProgress.ts
@@ -1,0 +1,70 @@
+/**
+ * Sprint 2 — 목표 체지방률 진행률 계산.
+ *
+ * 시작 체지방(시작 인증) → 현재 체지방(최신 주간 기록) → 목표 체지방(참가자 설정)
+ * 의 3점으로 "목표를 향해 얼마나 왔는가" 를 0~100% 로 환산한다. 순수 함수.
+ */
+
+export interface GoalProgress {
+  /** 목표·시작값이 모두 있어 진행률 표시가 가능한지. */
+  hasGoal: boolean;
+  startBodyFat: number | null;
+  currentBodyFat: number | null;
+  targetBodyFat: number | null;
+  /** 목표를 향한 진행률 0~100. 시작보다 후퇴 시 0, 목표 달성·초과 시 100. */
+  progressPct: number;
+  /** 목표 도달(현재 ≤ 목표) 여부. */
+  reached: boolean;
+  /** 목표까지 남은 %p. 양수=더 감량 필요, 음수=초과 달성. 값 없으면 null. */
+  remainingToTarget: number | null;
+  /** 시작 대비 변화 %p. 음수=감소(좋음). 값 없으면 null. */
+  deltaFromStart: number | null;
+}
+
+function round1(n: number): number {
+  return Math.round(n * 10) / 10;
+}
+
+export function computeGoalProgress(
+  startBodyFat: number | null | undefined,
+  currentBodyFat: number | null | undefined,
+  targetBodyFat: number | null | undefined
+): GoalProgress {
+  const start = startBodyFat ?? null;
+  const current = currentBodyFat ?? null;
+  const target = targetBodyFat ?? null;
+  const hasGoal = start != null && target != null;
+
+  const deltaFromStart =
+    start != null && current != null ? round1(current - start) : null;
+  const remainingToTarget =
+    current != null && target != null ? round1(current - target) : null;
+
+  let progressPct = 0;
+  let reached = false;
+
+  if (hasGoal) {
+    // current 가 없으면 아직 시작 지점 → 진행률 0.
+    const effectiveCurrent = current ?? start;
+    reached = effectiveCurrent != null && target != null && effectiveCurrent <= target;
+    const denom = (start as number) - (target as number); // 기대 총 감량 폭
+    if (denom <= 0) {
+      // 목표가 시작값과 같거나 더 높음(이미 쉬운 목표) → 도달했으면 100, 아니면 0.
+      progressPct = reached ? 100 : 0;
+    } else if (effectiveCurrent != null) {
+      const raw = (((start as number) - effectiveCurrent) / denom) * 100;
+      progressPct = Math.max(0, Math.min(100, Math.round(raw)));
+    }
+  }
+
+  return {
+    hasGoal,
+    startBodyFat: start,
+    currentBodyFat: current,
+    targetBodyFat: target,
+    progressPct,
+    reached,
+    remainingToTarget,
+    deltaFromStart,
+  };
+}

--- a/burnfat/src/pages/ChallengePage.tsx
+++ b/burnfat/src/pages/ChallengePage.tsx
@@ -62,6 +62,7 @@ import EndingSoonDialog, {
   dismissEndingSoonNotice,
 } from '../components/EndingSoonDialog';
 import RankingShareDialog from '../components/RankingShareDialog';
+import GoalProgressWidget from '../components/GoalProgressWidget';
 
 // Sprint 0.4: 디버그 플래그를 빌드 시점 환경 변수로 분리.
 //   - VITE_DEBUG_SHOW_RANKING="true"           → 순위 항상 공개 (개발 전용)
@@ -1012,6 +1013,14 @@ export default function ChallengePage() {
               개인 락 없음 · 공동 입력 · 공동 확인
             </Typography>
           </Box>
+          {/* Sprint 2: 목표 진행률 위젯 — 식별된 "나" 에 대해 상단 고정 */}
+          {myParticipant && (
+            <GoalProgressWidget
+              participant={myParticipant}
+              logs={logsByParticipant[myParticipant.id] || []}
+              onOpenBasicInfo={() => { setBasicInfoDialog(myParticipant); setBasicInfoDialogAfterJoin(false); }}
+            />
+          )}
           <RecordStatusSummary
             currentWeek={recordStatus.currentWeek}
             completedCount={recordStatus.completedCount}

--- a/burnfat/src/pages/CreateChallengePage.tsx
+++ b/burnfat/src/pages/CreateChallengePage.tsx
@@ -11,6 +11,8 @@ import LockIcon from '@mui/icons-material/Lock';
 import InputAdornment from '@mui/material/InputAdornment';
 import { supabase } from '../lib/supabase';
 import type { Challenge } from '../types';
+import ChallengeTemplatePicker from '../components/ChallengeTemplatePicker';
+import { CHALLENGE_TEMPLATES, templateEndDate, type ChallengeTemplate } from '../lib/challengeTemplates';
 
 function generateCode(): string {
   const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
@@ -39,6 +41,24 @@ export default function CreateChallengePage() {
   const [adminPin, setAdminPin] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
+  // Sprint 2: 선택된 챌린지 템플릿 id. 사용자가 값을 직접 수정하면 null(직접 설정).
+  const [selectedTemplateId, setSelectedTemplateId] = useState<string | null>(null);
+
+  // 템플릿 선택 → 종료일·참가비 자동 채움.
+  const handleSelectTemplate = (t: ChallengeTemplate) => {
+    setSelectedTemplateId(t.id);
+    setEndDate(templateEndDate(startDate, t.weeks));
+    setStakeAmount(t.stakeAmount);
+  };
+
+  // 시작일 변경 — 템플릿이 선택돼 있으면 종료일을 다시 계산해 일관성 유지.
+  const handleStartDateChange = (next: string) => {
+    setStartDate(next);
+    const tpl = selectedTemplateId
+      ? CHALLENGE_TEMPLATES.find((t) => t.id === selectedTemplateId)
+      : undefined;
+    if (tpl) setEndDate(templateEndDate(next, tpl.weeks));
+  };
 
   const handleCreate = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -103,6 +123,7 @@ export default function CreateChallengePage() {
 
       <Card sx={{ maxWidth: 480, mt: 2 }}>
         <CardContent sx={{ p: 3 }}>
+          <ChallengeTemplatePicker selectedId={selectedTemplateId} onSelect={handleSelectTemplate} />
           <form onSubmit={handleCreate}>
             <TextField
               fullWidth
@@ -116,7 +137,7 @@ export default function CreateChallengePage() {
               label="시작일"
               type="date"
               value={startDate}
-              onChange={(e) => setStartDate(e.target.value)}
+              onChange={(e) => handleStartDateChange(e.target.value)}
               InputLabelProps={{ shrink: true }}
               sx={{ mb: 2 }}
             />
@@ -125,7 +146,7 @@ export default function CreateChallengePage() {
               label="종료일"
               type="date"
               value={endDate}
-              onChange={(e) => setEndDate(e.target.value)}
+              onChange={(e) => { setEndDate(e.target.value); setSelectedTemplateId(null); }}
               InputLabelProps={{ shrink: true }}
               sx={{ mb: 2 }}
             />
@@ -134,7 +155,7 @@ export default function CreateChallengePage() {
               label="참가비 (원)"
               type="number"
               value={stakeAmount}
-              onChange={(e) => setStakeAmount(Number(e.target.value) || 0)}
+              onChange={(e) => { setStakeAmount(Number(e.target.value) || 0); setSelectedTemplateId(null); }}
               sx={{ mb: 2 }}
             />
             <TextField

--- a/burnfat/supabase/migrations/20260515000001_weekly_ai_advice.sql
+++ b/burnfat/supabase/migrations/20260515000001_weekly_ai_advice.sql
@@ -1,0 +1,39 @@
+-- BurnFat Sprint 2: AI 조언 서버 캐시 테이블 (weekly_ai_advice)
+--
+-- 목적
+--   - 동일 (participant_id, week_no, prompt_version) 의 AI 조언을 서버에 1회 캐시.
+--   - 같은 챌린지의 다른 친구가 같은 주차 조언을 열면 Grok 재호출 없이 캐시 반환
+--     → 토큰 비용 절감 + "공동 모니터링" 콘셉트와 일치.
+--   - 신선도(TTL)·강제 새로고침은 백엔드(burnfat_ai.py)가 updated_at 으로 판단.
+--
+-- 접근 모델
+--   - 백엔드(burnfat_ai.py)는 SUPABASE_SERVICE_ROLE_KEY 로 접근 → RLS 우회.
+--   - 클라이언트(anon)는 이 테이블에 직접 접근하지 않는다. 항상 백엔드 엔드포인트 경유.
+--   - 따라서 RLS 를 켜되 anon 정책을 만들지 않아 anon SELECT/INSERT/UPDATE/DELETE 전부 deny.
+--
+-- 캐시 무효화
+--   - Sprint 2: updated_at 기준 24h TTL + week_no 키 변경(새 주차) + 강제 새로고침 overwrite.
+--   - Sprint 2.5: weekly_logs INSERT/UPDATE 트리거 기반 자동 무효화로 확장 예정.
+
+CREATE TABLE IF NOT EXISTS weekly_ai_advice (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  participant_id  UUID NOT NULL REFERENCES participants(id) ON DELETE CASCADE,
+  week_no         INTEGER NOT NULL,
+  -- 프롬프트/스키마 버전. 프롬프트가 바뀌면 이 값을 올려 과거 캐시를 자연 무효화.
+  prompt_version  TEXT NOT NULL DEFAULT 'v1',
+  -- 사람이 읽는 평문 (구버전 클라이언트 호환 + 폴백 표시용).
+  advice_md       TEXT NOT NULL,
+  -- 구조화 응답 { summary, action_items[], cautions[] }.
+  advice_json     JSONB,
+  model           TEXT,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (participant_id, week_no, prompt_version)
+);
+
+CREATE INDEX IF NOT EXISTS weekly_ai_advice_lookup_idx
+  ON weekly_ai_advice (participant_id, week_no, prompt_version);
+
+ALTER TABLE weekly_ai_advice ENABLE ROW LEVEL SECURITY;
+
+-- 정책을 만들지 않음 = anon 전면 deny. service_role(백엔드)만 접근.


### PR DESCRIPTION
## Summary
Sprint 2 (제품 가치 확장) — Sprint 0 이후 처음으로 **백엔드·DB 변경 포함**. 배포 순서 무관하도록 graceful degrade 처리.

- **AI 조언 서버 캐시 + JSON 응답**: 신규 `weekly_ai_advice` 테이블(`UNIQUE(participant_id,week_no,prompt_version)` + RLS anon deny). `burnfat_ai.py` 재작성 — Grok 응답 JSON 구조화(`{summary,action_items,cautions}`), `(participant,week_no)` 서버 캐시 read-through+upsert(24h TTL), `week_no` 서버 계산, 입력 가드(user_context 500자 / style·goal 화이트리스트). `advice` 평문 필드 유지로 구버전 클라이언트 호환. 캐시 테이블 부재·오류 시 조언 생성은 계속. 프론트: `edgeFunctions` 구조화 파싱, `useAIAdvice` localStorage 캐시 제거(서버 캐시 대체), `AIAdviceCard` 섹션 분할 렌더 + 평문 폴백.
- **목표 진행률 위젯**: `goalProgress.ts`(순수) + `GoalProgressWidget`(시작/현재/목표 게이지, 목표 미설정 빈 상태). Tab 2 상단 식별된 \"나\"에게 고정 노출.
- **챌린지 템플릿**: `challengeTemplates.ts`(4/8/12주, 참가비 5만/10만/20만 + `templateEndDate`) + `ChallengeTemplatePicker`. `CreateChallengePage` 에서 선택 시 종료일·참가비 자동 채움.

상세·**배포 절차**·롤백: `burnfat/docs/SPRINT2_HANDOFF.md` (§4 배포, §7 롤백) · 로드맵: `IMPROVEMENT_REPORT_2026-05.md` §6 Sprint 2

## ⚠️ 배포 시 필요 (머지만으로 끝나지 않음)
1. **마이그레이션**: `burnfat/supabase/migrations/20260515000001_weekly_ai_advice.sql` 를 Supabase SQL Editor 에 적용
2. **백엔드**: `backend/routes/burnfat_ai.py` 변경 → Railway 재배포
3. **프론트엔드**: main 머지 시 Vercel 자동 배포

배포 순서는 무관 (백엔드는 캐시 테이블 없어도 동작, 프론트는 구버전 백엔드면 평문 폴백).

## Test plan
- [x] `npx tsc --noEmit` 클린
- [x] `npm run build` 성공
- [x] `npm test` 44/44 통과 (goalProgress 8 + challengeTemplates 7 + 기존 29)
- [x] `python3 -m py_compile backend/routes/burnfat_ai.py` 클린
- [ ] 배포 후: `/api/burnfat/ai/debug` 의 `weekly_ai_advice_ready:true` / AI 조언 구조화 섹션 렌더 / 캐시 hit 캡션 / 목표 진행률 게이지 / 템플릿 선택

🤖 Generated with [Claude Code](https://claude.com/claude-code)