### PR TITLE
fix(burnfat): pgcrypto search_path — 새 대결 생성 오류 핫픽스

### DIFF
--- a/burnfat/supabase/migrations/20260515000002_fix_pgcrypto_search_path.sql
+++ b/burnfat/supabase/migrations/20260515000002_fix_pgcrypto_search_path.sql
@@ -1,0 +1,37 @@
+-- BurnFat hotfix: pgcrypto search_path 수정
+--
+-- 증상
+--   새 대결 생성(PIN 입력 시) 또는 PIN 검증에서:
+--     ERROR: function gen_salt(unknown, integer) does not exist
+--   (crypt / digest 도 동일 원인으로 실패 가능)
+--
+-- 원인 (Sprint 0.1 잠복 버그)
+--   Supabase 는 pgcrypto 확장을 `extensions` 스키마에 *사전 설치*한다.
+--   Sprint 0.1 마이그레이션의 `CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA public`
+--   는 확장이 이미 존재하므로 no-op 이 되어, pgcrypto 함수(crypt/gen_salt/digest)는
+--   여전히 `extensions` 스키마에 남는다.
+--   그런데 PIN/해시 관련 SECURITY DEFINER 함수들은 `SET search_path = public, pg_temp`
+--   로 고정돼 있어 `extensions` 스키마의 함수를 해석하지 못한다.
+--   → PIN 없는 대결 생성·검증은 crypt 를 호출하지 않아 우연히 동작했고,
+--     PIN 이 개입하는 경로에서만 오류가 드러났다.
+--
+-- 핫픽스
+--   영향받는 함수의 search_path 에 `extensions` 를 추가한다. 함수 본문은 그대로.
+--   - search_path 에 public, extensions 를 모두 두므로 pgcrypto 가 어느 스키마에
+--     있든(공개 설치 환경 포함) 안전하게 해석된다.
+--   - search_path 는 미존재 스키마를 무시하므로 `extensions` 가 없어도 오류 없음.
+
+ALTER FUNCTION public.verify_admin_pin(UUID, TEXT)
+  SET search_path = public, extensions, pg_temp;
+
+ALTER FUNCTION public.create_challenge_with_pin(TEXT, TEXT, DATE, DATE, INTEGER, TEXT)
+  SET search_path = public, extensions, pg_temp;
+
+ALTER FUNCTION public.set_admin_pin(UUID, TEXT, TEXT)
+  SET search_path = public, extensions, pg_temp;
+
+-- _sha256_hex 는 search_path 미설정이라 호출자(update_submission/update_weekly_log,
+-- search_path=public,pg_temp) 컨텍스트에서 digest 를 못 찾을 수 있다.
+-- 자체 search_path 를 부여 → 어디서 호출되든 digest 해석 보장.
+ALTER FUNCTION public._sha256_hex(TEXT)
+  SET search_path = public, extensions, pg_temp;


### PR DESCRIPTION
## 증상
새 대결 생성(PIN 입력 시): `ERROR: function gen_salt(unknown, integer) does not exist`

## 원인 (Sprint 0.1 잠복 버그)
Supabase 는 `pgcrypto` 확장을 `extensions` 스키마에 사전 설치한다. Sprint 0.1 의 `CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA public` 은 확장이 이미 존재하므로 no-op → `crypt`/`gen_salt`/`digest` 는 `extensions` 에 남음. 그런데 PIN/해시 관련 SECURITY DEFINER 함수들의 `search_path` 가 `public, pg_temp` 뿐이라 해석 실패.

PIN 미개입 경로(PIN 없는 대결 생성·검증)는 `crypt` 를 호출하지 않아 우연히 동작했고, PIN 이 개입하는 경로에서만 오류가 드러났다.

## 핫픽스
`verify_admin_pin` / `create_challenge_with_pin` / `set_admin_pin` / `_sha256_hex` 의 `search_path` 에 `extensions` 추가 (`ALTER FUNCTION`, 함수 본문 불변). `public`·`extensions` 를 모두 두어 pgcrypto 가 어느 스키마에 있든 안전. `search_path` 는 미존재 스키마를 무시하므로 `extensions` 가 없는 환경에서도 오류 없음.

## 운영 적용 (필수)
`burnfat/supabase/migrations/20260515000002_fix_pgcrypto_search_path.sql` 을 Supabase SQL Editor 에 실행.

## 검증
적용 후 SQL Editor 에서:
```sql
SELECT create_challenge_with_pin('TESTAA','검증', CURRENT_DATE, CURRENT_DATE + 28, 50000, '1234');
-- 행 1개 반환 + admin_pin_hash 채워짐 → 성공. (테스트 후 DELETE FROM challenges WHERE code='TESTAA';)
```
또는 `/create` 에서 PIN 4자리로 새 대결 생성 → 정상 진입.

🤖 Generated with [Claude Code](https://claude.com/claude-code)