### PR TITLE
fix(burnfat): CORS allow_headers 에 X-Device-Secret 추가 (코치 핫픽스)

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -207,10 +207,13 @@ CORS(app,
          "origins": cors_origins,
          "supports_credentials": True,
          "allow_headers": [
-             "Content-Type", "Authorization", "X-Requested-With", 
+             "Content-Type", "Authorization", "X-Requested-With",
              "Cache-Control", "Accept", "Accept-Language",
              "Sec-Fetch-Site", "Sec-Fetch-Mode", "Sec-Fetch-Dest",
-             "Origin", "X-Safari-Auth-Token", "User-Agent"
+             "Origin", "X-Safari-Auth-Token", "User-Agent",
+             # BurnFat 코치(Sprint 2.5): 세션 소유권 검증용 커스텀 헤더.
+             # 누락 시 CORS preflight 가 막혀 코치 요청이 "Load failed" 로 실패.
+             "X-Device-Secret"
          ],
          "methods": ["GET", "POST", "PUT", "DELETE", "OPTIONS"]
      }})


### PR DESCRIPTION
## 증상
Sprint 2.5 코치 모달에서 세션 로드가 **"Load failed"** 로 실패 (시드 메시지는 표시되나 그 아래 빨간 에러).

## 원인
코치 요청(`coachClient`)은 세션 소유권 검증용 `X-Device-Secret` 커스텀 헤더를 보낸다. 커스텀 헤더는 CORS **preflight(OPTIONS)** 를 유발하는데, `app.py` 의 `CORS(app, resources={r"/api/*": {"allow_headers": [...]}})` 목록에 `X-Device-Secret` 이 없어, 브라우저가 preflight 응답의 `Access-Control-Allow-Headers` 에 해당 헤더가 없다고 판단 → 실제 요청을 차단 → `fetch()` 가 거부됨("Load failed").

AI 조언(`/ai/advice`)은 `X-Device-Secret` 를 안 보내 영향이 없었다.

## 핫픽스
`allow_headers` 리스트에 `X-Device-Secret` 추가 (1줄). 함수/로직 변경 없음.

## 적용
`backend/app.py` 변경 → **Railway 백엔드 재배포** 필요.

## 검증
재배포 후 코치 모달 진입 → "Load failed" 가 사라지고 빠른 답변 칩 → SSE 스트리밍 응답 정상.

🤖 Generated with [Claude Code](https://claude.com/claude-code)