### PR TITLE
fix(burnfat): coach /health 에 service_key_role 진단 추가

### DIFF
--- a/backend/routes/burnfat_coach.py
+++ b/backend/routes/burnfat_coach.py
@@ -14,6 +14,7 @@ BurnFat 대화형 코치 — Sprint 2.5.
 
 from __future__ import annotations
 
+import base64
 import hashlib
 import json
 import logging
@@ -125,6 +126,22 @@ def _sse(obj: dict[str, Any]) -> str:
 
 def _device_secret() -> str:
     return (request.headers.get("X-Device-Secret") or "").strip()
+
+
+def _service_key_role() -> str:
+    """SUPABASE_SERVICE_ROLE_KEY(JWT) 의 role 클레임만 디코드해 반환.
+    coach_* 테이블 쓰기는 service_role 이 필수 — 'anon' 이면 INSERT 가 RLS 로 막힌다.
+    키 값 자체는 노출하지 않고 role 만 본다(서명 검증 불필요)."""
+    _, key = _get_supabase_config()
+    if not key:
+        return "missing"
+    try:
+        payload_b64 = key.split(".")[1]
+        payload_b64 += "=" * (-len(payload_b64) % 4)
+        payload = json.loads(base64.urlsafe_b64decode(payload_b64))
+        return str(payload.get("role") or "unknown")
+    except Exception:  # noqa: BLE001 — 진단용, 모든 파싱 실패는 unparseable
+        return "unparseable"
 
 
 # ── Supabase REST 헬퍼 (insert/patch/count) ────────────────────────────────
@@ -459,6 +476,9 @@ def coach_health():
         "supabase_configured": bool(supabase_url and supabase_key),
         "xai_configured": bool(os.environ.get("XAI_API_KEY")),
         "coach_tables_ready": ready,
+        # coach_* 쓰기는 service_role 필수. 'anon' 이면 SUPABASE_SERVICE_ROLE_KEY
+        # 환경변수가 잘못 설정된 것(INSERT 가 401 로 실패).
+        "service_key_role": _service_key_role(),
         "model": XAI_MODEL,
     }), 200
 


### PR DESCRIPTION
## 증상
코치 세션 생성 시 화면 **"Failed to create session"**. 백엔드 로그:
```
coach session create failed: 401 Client Error: Unauthorized
  for url: https://...supabase.co/rest/v1/coach_sessions
```

## 진단
- coach_sessions **SELECT**(GET /sessions) → 200 성공
- coach_sessions **INSERT**(_create_session) → 401 실패

coach_* 테이블은 RLS ON + 정책 없음 → **service_role 키로만 쓰기 가능**. anon 키는 SELECT 시 빈 배열 200 이 나와 그동안(Sprint 0~2 의 읽기 전용 경로) 문제가 드러나지 않았다. 첫 service_role 쓰기 의존(coach_sessions INSERT)에서 401 로 표면화.

→ Railway 의 `SUPABASE_SERVICE_ROLE_KEY` 환경변수가 **service_role 이 아닌 anon 키**일 가능성이 높음. (Sprint 2 `weekly_ai_advice` 캐시 upsert 도 같은 이유로 조용히 실패해 왔을 것 — try/except 로 graceful degrade.)

## 이 PR
근본 수정이 아니라 **진단**. `/api/burnfat/coach/health` 가 `SUPABASE_SERVICE_ROLE_KEY`(JWT) 의 `role` 클레임만 base64 디코드해 `service_key_role` 로 노출 (키 값 자체는 노출 안 함, 서명 검증 불필요).

## 실제 수정 (운영자 작업 — 코드 아님)
Railway → backend 서비스 → Variables → `SUPABASE_SERVICE_ROLE_KEY` 를 Supabase Dashboard → Settings → API → **`service_role` `secret` 키**로 교체. (현재 값은 `anon` `public` 키로 추정.)

## 검증
재배포 후 `GET /api/burnfat/coach/health` → `"service_key_role"` 이
- `"anon"` → 환경변수 교체 필요
- `"service_role"` → 정상, 코치 세션 생성 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)