### PR TITLE
refactor(burnfat): Sprint 3 Phase B — ChallengePage 분해 + N+1 제거 + 훅 테스트

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,8 @@ crossfit-system/
 | **2** | AI 조언 서버 캐시 + JSON 응답 / 목표 진행률 / 챌린지 템플릿 | ✅ **완료 (코드)** — `weekly_ai_advice` 캐시 테이블 + `burnfat_ai.py` JSON 구조화·서버 캐시·입력 가드 / `GoalProgressWidget`+`goalProgress.ts` / `ChallengeTemplatePicker`+`challengeTemplates.ts` + vitest 44/44. ⚠️ 마이그레이션·백엔드 배포 필요. 상세: [`burnfat/docs/SPRINT2_HANDOFF.md`](burnfat/docs/SPRINT2_HANDOFF.md) |
 | **2.5** | 대화형 코치 모달 + 세션·장기 메모리 영속화 | ✅ **완료 (코드)** — `coach_sessions`/`coach_messages`/`participant_coach_memory` 마이그레이션 3건 + `burnfat_coach.py`(SSE 스트리밍·세션·메모리·가드) + `CoachChatDialog`/`useCoachSession`/`coachClient` + AIAdviceCard "코치와 대화하기" CTA. ⚠️ 마이그레이션·백엔드 배포 필요. 상세: [`burnfat/docs/SPRINT2_5_HANDOFF.md`](burnfat/docs/SPRINT2_5_HANDOFF.md) |
 | **3 — Phase A** | 배포 토폴로지 정리 / `challenges_public` VIEW / 운영 안전망 BE-1·2·3 / Vitest 인프라(jsdom) | ✅ **완료 (코드)** — root `railway.json` gunicorn 통일 + README 배포 매트릭스 / `challenges_public` VIEW 마이그레이션 + 클라이언트 전환 / `burnfat_ai.py`·`burnfat_coach.py` 모델 부팅 검증·Grok 오류 본문 로깅·`last_advice_success_at` health 노출 / Vitest jsdom + testing-library + CI 배선 + vitest 48/48. ⚠️ VIEW 마이그레이션 적용·백엔드 배포 필요. `backend/railway.*` 삭제는 보류(Root Directory `/backend`). 상세: [`burnfat/docs/SPRINT3A_HANDOFF.md`](burnfat/docs/SPRINT3A_HANDOFF.md) |
-| **3 — Phase B** | ChallengePage 분해 / N+1 제거 / 기존 훅 테스트 작성 / Playwright / 분석 이벤트 | ⏳ 미착수 |
+| **3 — Phase B** | ChallengePage 분해 / N+1 제거 / 훅·lib 단위 테스트 | ✅ **완료 (코드)** — `ChallengePage.tsx` 1,262→345줄 + `useChallengeData` 훅·신규 11개 파일 분리 / `participants.select('*, submissions(*)')` 임베드로 진입 REST `2+N`→`3` / Vitest 48→79. ⚠️ DoD ≤100줄 미달(345줄, 탭 교차 모달 조율 잔존). 배포·DB 변경 없음(프런트 전용). 상세: [`burnfat/docs/SPRINT3B_HANDOFF.md`](burnfat/docs/SPRINT3B_HANDOFF.md) |
+| **3 — Phase C** | Playwright E2E / 분석 이벤트 / ChallengePage 추가 축소 | ⏳ 미착수 |
 
 작업 시작 시 항상 다음 순서를 지키세요.
 

--- a/burnfat/docs/IMPROVEMENT_REPORT_2026-05.md
+++ b/burnfat/docs/IMPROVEMENT_REPORT_2026-05.md
@@ -486,14 +486,19 @@ Sprint 3 은 위험·범위를 고려해 **Phase A(저위험 인프라 정리)**
 - 운영 안전망 BE-1/2/3 — xAI 모델 부팅 검증, Grok 오류 본문 로깅, `last_advice_success_at` health 노출.
 - Vitest 인프라(jsdom + testing-library) 셋업 + CI 배선. 실제 훅/컴포넌트 테스트는 Phase B.
 
-**Phase B — 구조 개편 (미착수)**
-1. **`ChallengePage` 분해** (3~5일)
-   - `useChallengeData` hook으로 fetch 통합, Supabase 임베드 쿼리로 N+1 제거.
-   - 탭별 컴포넌트 분리.
-2. **테스트 베이스라인** (3일)
-   - Vitest 단위 테스트(훅 3종), Playwright 1개 E2E, GitHub Actions에 배선.
-3. **분석 이벤트** (2일)
-   - PostHog/Plausible 도입 → 챌린지 생성/참가/인증/AI 요청 5개 이벤트만.
+**Phase B — 구조 개편 ✅ 완료 (2026-05-19, [`SPRINT3B_HANDOFF.md`](SPRINT3B_HANDOFF.md))**
+1. **`ChallengePage` 분해 ✅** — `ChallengePage.tsx` 1,262줄 → 345줄(73%↓). `useChallengeData`
+   훅 + 신규 11개 파일(`rankAnimations`/`ChallengeHeader`/`ChallengeTabs`/3개 탭/`AdminPinDialog`/
+   `ChallengeEditDialog`/`ChallengeOverlays`/`ParticipantsTabHeader`)로 분리.
+   ⚠️ DoD ≤100줄은 미달(345줄) — 탭 교차 모달 조율이 페이지에 남음. 핸드오프 §1 참고.
+2. **N+1 쿼리 제거 ✅** — `participants.select('*, submissions(*)')` 임베드. 진입 REST 호출 `2+N` → `3`.
+3. **단위 테스트 ✅** — Vitest 48 → 79(신규 31). `useRecordStatus`/`useWeeklyLogs`/`useAIAdvice`/
+   `useCoachSession`/`signedImage` + `deviceSecret` 보강.
+
+**Phase C — 미착수**
+- Playwright 1개 E2E (참가→시작 인증→주간 기록 골든 패스).
+- 분석 이벤트 — PostHog/Plausible 도입 → 챌린지 생성/참가/인증/AI 요청 5개 이벤트만.
+- `ChallengePage` 추가 축소(`useChallengePage` 컨트롤러 훅).
 
 ### 분기 백로그 (3~6개월)
 

--- a/burnfat/docs/SPRINT3B_HANDOFF.md
+++ b/burnfat/docs/SPRINT3B_HANDOFF.md
@@ -1,0 +1,151 @@
+# Sprint 3 Phase B 핸드오프 — 구조 개편(ChallengePage 분해) 완료 보고
+
+> **상태**: ✅ 완료 (코드)
+> **날짜**: 2026-05-19
+> **커밋**: (push 시 SHA 기입)
+> **배포**: Vercel 자동 배포 트리거 (burnfat) — DB/백엔드 변경 없음
+> **DB 적용 필요**: 없음 (마이그레이션·RPC·스키마 무변경)
+
+Phase B 는 **기능 보존 리팩터**다. 코드 동작 추가/제거 없이 `ChallengePage` 메가 컴포넌트를
+분해하고, N+1 쿼리를 제거하고, 훅·lib 단위 테스트를 작성했다.
+
+---
+
+## 1. 적용된 변경
+
+### B1. `ChallengePage` 분해
+
+`src/pages/ChallengePage.tsx` 를 **1,262줄 → 345줄** (약 73% 감소) 로 줄이고, 책임을
+신규 11개 파일로 분리했다.
+
+| 신규 파일 | 책임 |
+|-----------|------|
+| `hooks/useChallengeData.ts` | challenge + participants(+submissions) + weekly_logs 통합 페치, ranking 파생, 로딩 경과 타이머 |
+| `theme/rankAnimations.ts` | 인라인 sx keyframes → `styled()` 추출 (`EndAuthButton`/`RankOneRow`/`RankMedal`) |
+| `components/ChallengeHeader.tsx` | 제목·기간·코드·D-Day 칩·수정/복사 버튼 |
+| `components/ChallengeTabs.tsx` | sticky 3-탭 바 |
+| `components/ParticipantsTabHeader.tsx` | Tab 0 *탭 바 위* 영역 — 개인 상태 카드 / 참가 폼 |
+| `components/ParticipantsTab.tsx` | Tab 0 참가자 카드 목록 (인증 버튼) |
+| `components/RankingTab.tsx` | Tab 1 순위 — 진행 상태·중간 공개 토글·순위표·결과 공유 |
+| `components/WeeklyLogsTab.tsx` | Tab 2 주간 기록 — 요약·차트·참가자별 카드 |
+| `components/AdminPinDialog.tsx` | PIN 다이얼로그 + `verify_admin_pin` RPC |
+| `components/ChallengeEditDialog.tsx` | 챌린지 기본정보 수정 |
+| `components/ChallengeOverlays.tsx` | 탭을 가로지르는 모달·다이얼로그·스낵바 레이어 (표현 전용) |
+
+분해 후 `ChallengePage` 의 역할: `useChallengeData` 호출 → 4개 파생 훅 배선 →
+탭/오버레이 상태 조율 → 헤더·탭·오버레이 렌더.
+
+> ⚠️ **DoD ≤100줄 미달성 (실제 345줄).** 8개 오버레이 모달이 탭을 가로질러
+> 트리거되므로(예: `SubmitModal` 은 Tab 0 카드·개인 상태 카드·종료 임박 모달에서 모두 호출)
+> 상태·핸들러를 페이지에 두는 것이 충실한 보존이다. 이를 100줄 아래로 강제하려면
+> 30개 prop 의 메가 컴포넌트 또는 페이지 로직의 컨트롤러 훅 이관이 필요한데,
+> 전자는 스펙의 "drilling 최소" 원칙에 반하고 후자는 "회귀 0" 절대 목표에 위험을
+> 더한다. 73% 감소 + 11개 단일 책임 파일로 분해의 *실질 목표*는 달성했다.
+> 추가 축소(컨트롤러 훅)는 후속 안전 작업으로 분리 권장.
+
+### B2. N+1 쿼리 제거
+
+기존 `fetchParticipants` 는 참가자마다 `submissions` 를 개별 SELECT 했다 → `1 + N` 호출.
+
+```ts
+// 변경 후 (useChallengeData.ts)
+await supabase
+  .from('participants')
+  .select('*, submissions(*)')   // ← Supabase 임베드: 1회 호출
+  .eq('challenge_id', challenge.id)
+  .order('created_at');
+```
+
+**진입 시 REST 호출 = 정확히 3건:**
+1. `challenges_public` — code 로 챌린지 1건
+2. `participants` + `submissions(*)` 임베드 — 전 참가자 인증 (N+1 제거)
+3. `weekly_logs` `.in('participant_id', …)` — 전 참가자 주간 기록 (`useAllWeeklyLogsForChallenge`, 무변경)
+
+참가자가 N명이면 기존 `2 + N` → `3` 으로. ranking/정렬/감소율 계산 로직은 동일하다
+(`.find()` 기반이라 임베드 정렬 순서 무관).
+
+### B3. 단위 테스트 작성
+
+Phase A 의 Vitest jsdom 인프라 위에 훅·lib 테스트를 추가. **48 → 79 테스트** (신규 31개).
+
+| 파일 | 케이스 |
+|------|--------|
+| `hooks/__tests__/useRecordStatus.test.ts` | 7 — currentWeek 계산, completed/notCompleted 분류, 누적 입력률 |
+| `hooks/__tests__/useWeeklyLogs.test.ts` | 3 — supabase mock fetch / null guard / insert |
+| `hooks/__tests__/useAIAdvice.test.ts` | 4 — cache hit/miss, forceRefresh 전달, error 분기 |
+| `hooks/__tests__/useCoachSession.test.ts` | 3 — 세션 복원(system 제외·메모리 인용), 시드, send 추가 |
+| `lib/__tests__/signedImage.test.ts` | 9 — extractStoragePath(path/public/sign/외부) + isStoragePath |
+| `lib/__tests__/deviceSecret.test.ts` | +5 — save/load/clear 라운드트립, table 분리, prepareDeviceSecret |
+
+`hooks/useNextRecordableWeek.test.ts` (12)는 Sprint 1.5 에서 이미 5단계 상태 + missingWeeks 를
+커버하므로 그대로 둔다.
+
+---
+
+## 2. 의도된 동작 변경 (1건) — 보고
+
+**`prefers-reduced-motion` 분기 추가.** 기존 1위 행/메달/종료 버튼 애니메이션은
+reduce-motion 설정을 무시했다. `rankAnimations.ts` 추출 시 스펙 요구사항
+("prefers-reduced-motion 분기 포함") 과 CLAUDE.md §6 에 따라
+`@media (prefers-reduced-motion: reduce) { animation: none }` 을 추가했다.
+→ reduce-motion 사용자에게만 데코 애니메이션이 정지된다. 그 외 사용자는 시각·동작 동일.
+
+그 밖에는 동작 변경 0 — 상태 병합(`basicInfoDialog`+`afterJoin` → 객체 1개),
+join 에러를 공유 `error` → `ParticipantsTabHeader` 로컬 상태로 이동 등은 모두
+사용자 화면에 동일하게 보인다.
+
+---
+
+## 3. 검증 결과 (DoD)
+
+| 항목 | 결과 |
+|------|------|
+| `tsc --noEmit` | ✅ 0 exit |
+| `npm test` | ✅ 79 통과 (11 파일) |
+| `npm run build` | ✅ 성공 (1,414 모듈) |
+| 진입 시 REST 호출 N+1 → 3건 이내 | ✅ 3건 |
+| `ChallengePage.tsx` ≤ 100줄 | ⚠️ 345줄 (§1 B1 참고 — 실질 목표는 달성) |
+| 운영 회귀 0 | ⏳ 수동 시나리오 검증 필요 (§4) |
+
+---
+
+## 4. 운영자 수동 회귀 검증 시나리오 (6+개)
+
+`burnfat.wodybody.com` 또는 `npm run dev` 에서 기존 챌린지 코드로 확인:
+
+1. **진입** — 코드로 페이지 로드, 헤더(제목·기간·코드·D-Day)·3탭 정상.
+2. **참가** — 닉네임 입력 → 참가 → 기본정보 다이얼로그 진입 → "나" 로 기억(개인 상태 카드).
+3. **시작 인증** — 참가자 카드 "시작일 인증" → 이미지 마스킹·제출 → 카드에 체지방률 반영.
+4. **종료 인증** — "종료일 인증"(종료일 전이면 차단 스낵바) → 제출 → 종료 처리.
+5. **순위** — Tab 1 진행 상태·중간 공개 토글(PIN 설정 시 PIN 다이얼로그)·순위표·결과 공유.
+6. **주간 기록** — Tab 2 요약·차트·참가자별 카드, 다음 차주 입력 CTA, WeeklyLogForm 입력.
+7. **AI/코치** — `ParticipantWeeklyLogCard` 의 AI 조언 카드 → "코치와 대화하기" 모달.
+8. **챌린지 수정** — 헤더 연필 아이콘 → (PIN) → 이름·기간·참가비 수정 반영.
+
+**DevTools Network 호출 수 비교** (핵심 검증):
+- Network 탭 → `XHR/Fetch` 필터 → `supabase.co/rest/v1` 호출만 카운트.
+- 페이지 진입 시 `challenges_public` 1 + `participants?select=*,submissions(*)` 1 +
+  `weekly_logs?...in.(...)` 1 = **3건**.
+- 참가자 N명일 때 기존 `2 + N` 대비 절반 이하인지 확인 (참가자 4명 → 기존 6 → 현재 3).
+
+---
+
+## 5. 롤백 가이드
+
+- 본 변경은 **프런트 전용** (DB·RPC·백엔드 무변경). 긴급 시 Vercel Deployments 에서
+  직전 배포로 *Promote to Production*.
+- 코드 롤백은 본 커밋 1건 revert 로 완결 (마이그레이션 정리 불요).
+
+---
+
+## 6. 다음 단계 — Sprint 3 Phase C 예고
+
+1. **`ChallengePage` 추가 축소** — 페이지 상태/핸들러를 `useChallengePage` 컨트롤러 훅으로
+   이관해 ≤100줄에 근접시키기 (B1 의 후속 안전 작업).
+2. **Playwright E2E 1개** — 참가 → 시작 인증 → 주간 기록 골든 패스.
+3. **분석 이벤트** — PostHog/Plausible 도입, 핵심 5개 이벤트(생성/참가/인증/AI/코치) 계측.
+4. **기존 컴포넌트 테스트** — testing-library 로 탭 컴포넌트 렌더 테스트.
+
+진입 시 루트 `CLAUDE.md` → 본 문서 → `IMPROVEMENT_REPORT_2026-05.md` Sprint 3 순으로 읽을 것.
+
+— 끝 —

--- a/burnfat/src/components/AdminPinDialog.tsx
+++ b/burnfat/src/components/AdminPinDialog.tsx
@@ -1,0 +1,142 @@
+import { useEffect, useState } from 'react';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import Typography from '@mui/material/Typography';
+import TextField from '@mui/material/TextField';
+import Button from '@mui/material/Button';
+import InputAdornment from '@mui/material/InputAdornment';
+import LockIcon from '@mui/icons-material/Lock';
+import { supabase } from '../lib/supabase';
+
+export type AdminPinAction = 'ranking' | 'editChallenge';
+
+interface AdminPinDialogProps {
+  open: boolean;
+  challengeId: string;
+  action: AdminPinAction;
+  onClose: () => void;
+  /**
+   * PIN 검증 성공 후 실행할 후속 액션.
+   * 반환 boolean 이 true 면 다이얼로그를 닫는다 (false 면 열린 채 유지).
+   */
+  onConfirmed: () => Promise<boolean>;
+}
+
+const normalizeAdminPin = (p: string | null | undefined) =>
+  String(p ?? '').trim().replace(/\D/g, '');
+
+/**
+ * Sprint 3 Phase B — 관리자 PIN 확인 다이얼로그.
+ * Sprint 0.1 의 서버 RPC(`verify_admin_pin`) 검증을 그대로 사용한다.
+ */
+export default function AdminPinDialog({
+  open,
+  challengeId,
+  action,
+  onClose,
+  onConfirmed,
+}: AdminPinDialogProps) {
+  const [pinInput, setPinInput] = useState('');
+  const [pinError, setPinError] = useState('');
+  const [pinLoading, setPinLoading] = useState(false);
+
+  // 다이얼로그가 열릴 때마다 입력 상태를 초기화.
+  useEffect(() => {
+    if (open) {
+      setPinInput('');
+      setPinError('');
+      setPinLoading(false);
+    }
+  }, [open]);
+
+  // Sprint 0.1: 클라이언트 비교가 아닌 서버 RPC 로 PIN 검증.
+  const verifyAdminPinOnServer = async (pin: string): Promise<boolean> => {
+    const cleaned = normalizeAdminPin(pin);
+    if (cleaned.length !== 4) return false;
+    const { data, error } = await supabase.rpc('verify_admin_pin', {
+      p_challenge_id: challengeId,
+      p_pin: cleaned,
+    });
+    if (error) return false;
+    return data === true;
+  };
+
+  const handleSubmit = async () => {
+    const got = normalizeAdminPin(pinInput);
+    if (got.length !== 4) {
+      setPinError('PIN은 숫자 4자리입니다.');
+      return;
+    }
+    setPinLoading(true);
+    setPinError('');
+    const ok = await verifyAdminPinOnServer(got);
+    if (!ok) {
+      setPinLoading(false);
+      setPinError('PIN이 올바르지 않습니다.');
+      return;
+    }
+    const done = await onConfirmed();
+    setPinLoading(false);
+    if (done) {
+      setPinInput('');
+      onClose();
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogTitle sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        <LockIcon sx={{ fontSize: 20, color: 'warning.main' }} />
+        관리자 PIN 확인
+      </DialogTitle>
+      <DialogContent>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          {action === 'editChallenge'
+            ? '챌린지 정보 수정은 관리자 PIN이 필요합니다.'
+            : '순위 공개/잠금은 관리자 PIN이 필요합니다.'}
+        </Typography>
+        <TextField
+          fullWidth
+          label="PIN 4자리"
+          type="text"
+          inputProps={{ maxLength: 4, inputMode: 'numeric', pattern: '[0-9]*' }}
+          value={pinInput}
+          onChange={(e) => {
+            const v = e.target.value.replace(/\D/g, '').slice(0, 4);
+            setPinInput(v);
+            setPinError('');
+          }}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && !pinLoading) void handleSubmit();
+          }}
+          error={!!pinError}
+          helperText={pinError}
+          autoFocus
+          disabled={pinLoading}
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <LockIcon sx={{ fontSize: 16, color: 'text.disabled' }} />
+              </InputAdornment>
+            ),
+          }}
+        />
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2 }}>
+        <Button onClick={onClose} color="inherit" disabled={pinLoading}>
+          취소
+        </Button>
+        <Button
+          variant="contained"
+          color="warning"
+          onClick={() => void handleSubmit()}
+          disabled={pinLoading || pinInput.length !== 4}
+        >
+          {pinLoading ? '처리 중...' : '확인'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/burnfat/src/components/ChallengeEditDialog.tsx
+++ b/burnfat/src/components/ChallengeEditDialog.tsx
@@ -1,0 +1,145 @@
+import { useEffect, useState } from 'react';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import TextField from '@mui/material/TextField';
+import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+import EditIcon from '@mui/icons-material/Edit';
+import { supabase } from '../lib/supabase';
+import type { Challenge } from '../types';
+
+interface ChallengeEditDialogProps {
+  open: boolean;
+  challenge: Challenge;
+  onClose: () => void;
+  /** 저장 성공 후 갱신된 챌린지를 전달. */
+  onSaved: (updated: Challenge) => void;
+}
+
+/**
+ * Sprint 3 Phase B — 챌린지 기본정보(이름·기간·참가비) 수정 다이얼로그.
+ * VIEW 는 read-only 이므로 UPDATE 는 base 테이블 `challenges` 를 직접 사용한다.
+ */
+export default function ChallengeEditDialog({
+  open,
+  challenge,
+  onClose,
+  onSaved,
+}: ChallengeEditDialogProps) {
+  const [title, setTitle] = useState('');
+  const [startDate, setStartDate] = useState('');
+  const [endDate, setEndDate] = useState('');
+  const [stakeAmount, setStakeAmount] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  // 다이얼로그가 열릴 때 현재 챌린지 값으로 폼을 초기화.
+  useEffect(() => {
+    if (open) {
+      setTitle(challenge.title);
+      setStartDate(challenge.start_date);
+      setEndDate(challenge.end_date);
+      setStakeAmount(challenge.stake_amount);
+      setError('');
+    }
+  }, [open, challenge]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!title.trim()) {
+      setError('대결 이름을 입력하세요.');
+      return;
+    }
+    if (!startDate || !endDate) {
+      setError('기간을 입력하세요.');
+      return;
+    }
+    if (startDate >= endDate) {
+      setError('종료일은 시작일 이후여야 합니다.');
+      return;
+    }
+    setLoading(true);
+    setError('');
+    const { error: err } = await supabase
+      .from('challenges')
+      .update({
+        title: title.trim(),
+        start_date: startDate,
+        end_date: endDate,
+        stake_amount: stakeAmount,
+      })
+      .eq('id', challenge.id);
+    setLoading(false);
+    if (err) {
+      setError(err.message);
+      return;
+    }
+    onSaved({
+      ...challenge,
+      title: title.trim(),
+      start_date: startDate,
+      end_date: endDate,
+      stake_amount: stakeAmount,
+    });
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        <EditIcon sx={{ fontSize: 20 }} />
+        챌린지 정보 수정
+      </DialogTitle>
+      <form onSubmit={handleSubmit}>
+        <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2, pt: 1 }}>
+          <TextField
+            fullWidth
+            label="대결 이름"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            required
+          />
+          <TextField
+            fullWidth
+            label="시작일"
+            type="date"
+            value={startDate}
+            onChange={(e) => setStartDate(e.target.value)}
+            InputLabelProps={{ shrink: true }}
+          />
+          <TextField
+            fullWidth
+            label="종료일"
+            type="date"
+            value={endDate}
+            onChange={(e) => setEndDate(e.target.value)}
+            InputLabelProps={{ shrink: true }}
+          />
+          <TextField
+            fullWidth
+            label="참가비 (원)"
+            type="number"
+            value={stakeAmount}
+            onChange={(e) => setStakeAmount(Number(e.target.value) || 0)}
+            inputProps={{ min: 0 }}
+          />
+          {error && (
+            <Typography color="error" variant="body2">
+              {error}
+            </Typography>
+          )}
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 2 }}>
+          <Button onClick={onClose} color="inherit">
+            취소
+          </Button>
+          <Button type="submit" variant="contained" disabled={loading}>
+            {loading ? '저장 중...' : '저장'}
+          </Button>
+        </DialogActions>
+      </form>
+    </Dialog>
+  );
+}

--- a/burnfat/src/components/ChallengeHeader.tsx
+++ b/burnfat/src/components/ChallengeHeader.tsx
@@ -1,0 +1,87 @@
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
+import EditIcon from '@mui/icons-material/Edit';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import type { Challenge } from '../types';
+import type { DDayDisplay } from '../lib/challengeSchedule';
+import DDayChip from './DDayChip';
+
+interface ChallengeHeaderProps {
+  challenge: Challenge;
+  dday: DDayDisplay;
+  /** 챌린지 정보 수정 진입 (PIN 게이팅은 호출 측에서 처리). */
+  onEditClick: () => void;
+  /** 대결 URL 복사. */
+  onCopyShare: () => void;
+}
+
+/**
+ * Sprint 3 Phase B — ChallengePage 상단 헤더.
+ * 제목·기간·참가비·대결 코드 + D-Day 칩 + 수정/복사 버튼.
+ */
+export default function ChallengeHeader({
+  challenge,
+  dday,
+  onEditClick,
+  onCopyShare,
+}: ChallengeHeaderProps) {
+  return (
+    <Box sx={{ px: 2, pb: 2 }}>
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'flex-start',
+          gap: 1,
+        }}
+      >
+        <Box>
+          <Typography variant="h5" fontWeight={700} gutterBottom>
+            {challenge.title}
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            {challenge.start_date} ~ {challenge.end_date} · 참가비{' '}
+            {challenge.stake_amount.toLocaleString()}원
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            대결 코드: <strong>{challenge.code}</strong>
+          </Typography>
+        </Box>
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'flex-end',
+            gap: 0.5,
+          }}
+        >
+          <DDayChip dday={dday} />
+          <Box sx={{ display: 'flex', gap: 0.5 }}>
+            <Tooltip title="챌린지 정보 수정">
+              <IconButton
+                onClick={onEditClick}
+                size="small"
+                color="default"
+                aria-label="챌린지 정보 수정"
+              >
+                <EditIcon />
+              </IconButton>
+            </Tooltip>
+            <Tooltip title="URL 복사">
+              <IconButton
+                onClick={onCopyShare}
+                color="primary"
+                size="small"
+                aria-label="대결 URL 복사"
+              >
+                <ContentCopyIcon />
+              </IconButton>
+            </Tooltip>
+          </Box>
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/burnfat/src/components/ChallengeOverlays.tsx
+++ b/burnfat/src/components/ChallengeOverlays.tsx
@@ -1,0 +1,194 @@
+import Snackbar from '@mui/material/Snackbar';
+import type { Challenge, ParticipantWithSubmissions, WeeklyLog } from '../types';
+import type { DDayDisplay } from '../lib/challengeSchedule';
+import SubmitModal from './SubmitModal';
+import ParticipantBasicInfoDialog from './ParticipantBasicInfoDialog';
+import WeeklyLogForm from './WeeklyLogForm';
+import ChallengeEditDialog from './ChallengeEditDialog';
+import AdminPinDialog, { type AdminPinAction } from './AdminPinDialog';
+import EndingSoonDialog from './EndingSoonDialog';
+import WeeklyLogsUpgradeNoticeDialog from './WeeklyLogsUpgradeNoticeDialog';
+
+/** 시작/종료 인증 모달의 대상. */
+export interface SubmitTarget {
+  participantId: string;
+  participantNickname: string;
+  type: 'start' | 'end';
+}
+
+interface ChallengeOverlaysProps {
+  challenge: Challenge;
+  logsByParticipant: Record<string, WeeklyLog[]>;
+  myParticipant: ParticipantWithSubmissions | null;
+  endDateOnly: string;
+  dday: DDayDisplay;
+
+  submitTarget: SubmitTarget | null;
+  onCloseSubmit: () => void;
+  onSubmitSuccess: () => void;
+
+  basicInfo: { participant: ParticipantWithSubmissions; afterJoin: boolean } | null;
+  onCloseBasicInfo: () => void;
+  onBasicInfoSuccess: () => void;
+
+  weeklyLogTarget: { participant: ParticipantWithSubmissions; defaultWeekNo?: number } | null;
+  onCloseWeeklyLog: () => void;
+  onWeeklyLogSuccess: () => void;
+
+  copySnackbar: boolean;
+  onCloseCopy: () => void;
+  earlyEndSnackbar: boolean;
+  onCloseEarlyEnd: () => void;
+  toast: string | null;
+  onCloseToast: () => void;
+
+  pinAction: AdminPinAction | null;
+  onClosePin: () => void;
+  onPinConfirmed: () => Promise<boolean>;
+
+  editOpen: boolean;
+  onCloseEdit: () => void;
+  onSavedEdit: (updated: Challenge) => void;
+
+  endingSoonOpen: boolean;
+  onCloseEndingSoon: () => void;
+  onAuthEndMy: (() => void) | undefined;
+
+  weeklyLogsNoticeOpen: boolean;
+  onCloseWeeklyLogsNotice: () => void;
+}
+
+/**
+ * Sprint 3 Phase B — ChallengePage 의 오버레이 레이어.
+ * 탭에 걸쳐 호출되는 모달·다이얼로그·스낵바를 한 곳에 모은 *표현 전용* 컴포넌트.
+ * 상태와 핸들러는 모두 ChallengePage 가 소유하고, 여기서는 렌더만 한다.
+ */
+export default function ChallengeOverlays({
+  challenge,
+  logsByParticipant,
+  myParticipant,
+  endDateOnly,
+  dday,
+  submitTarget,
+  onCloseSubmit,
+  onSubmitSuccess,
+  basicInfo,
+  onCloseBasicInfo,
+  onBasicInfoSuccess,
+  weeklyLogTarget,
+  onCloseWeeklyLog,
+  onWeeklyLogSuccess,
+  copySnackbar,
+  onCloseCopy,
+  earlyEndSnackbar,
+  onCloseEarlyEnd,
+  toast,
+  onCloseToast,
+  pinAction,
+  onClosePin,
+  onPinConfirmed,
+  editOpen,
+  onCloseEdit,
+  onSavedEdit,
+  endingSoonOpen,
+  onCloseEndingSoon,
+  onAuthEndMy,
+  weeklyLogsNoticeOpen,
+  onCloseWeeklyLogsNotice,
+}: ChallengeOverlaysProps) {
+  return (
+    <>
+      {submitTarget && (
+        <SubmitModal
+          open
+          participantId={submitTarget.participantId}
+          participantNickname={submitTarget.participantNickname}
+          type={submitTarget.type}
+          onClose={onCloseSubmit}
+          onSuccess={onSubmitSuccess}
+        />
+      )}
+
+      <WeeklyLogsUpgradeNoticeDialog
+        open={weeklyLogsNoticeOpen}
+        onClose={onCloseWeeklyLogsNotice}
+      />
+
+      <Snackbar
+        open={copySnackbar}
+        autoHideDuration={2000}
+        onClose={onCloseCopy}
+        message="URL이 복사되었습니다"
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      />
+      <Snackbar
+        open={earlyEndSnackbar}
+        autoHideDuration={4000}
+        onClose={onCloseEarlyEnd}
+        message={`종료일(${endDateOnly || challenge.end_date}) 이후에 인증이 가능합니다.`}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+        sx={{ '& .MuiSnackbarContent-root': { bgcolor: 'warning.dark' } }}
+      />
+      <Snackbar
+        open={!!toast}
+        autoHideDuration={3000}
+        onClose={onCloseToast}
+        message={toast}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      />
+
+      <ChallengeEditDialog
+        open={editOpen}
+        challenge={challenge}
+        onClose={onCloseEdit}
+        onSaved={onSavedEdit}
+      />
+
+      {pinAction && (
+        <AdminPinDialog
+          open
+          challengeId={challenge.id}
+          action={pinAction}
+          onClose={onClosePin}
+          onConfirmed={onPinConfirmed}
+        />
+      )}
+
+      {basicInfo && (
+        <ParticipantBasicInfoDialog
+          open
+          participant={basicInfo.participant}
+          onClose={onCloseBasicInfo}
+          onSuccess={onBasicInfoSuccess}
+          isAfterJoin={basicInfo.afterJoin}
+        />
+      )}
+
+      {weeklyLogTarget && (
+        <WeeklyLogForm
+          open
+          participant={weeklyLogTarget.participant}
+          challengeStartDate={challenge.start_date}
+          challengeEndDate={challenge.end_date}
+          existingWeekNos={(logsByParticipant[weeklyLogTarget.participant.id] || []).map(
+            (l) => l.week_no
+          )}
+          defaultWeekNo={weeklyLogTarget.defaultWeekNo}
+          onClose={onCloseWeeklyLog}
+          onSuccess={onWeeklyLogSuccess}
+        />
+      )}
+
+      <EndingSoonDialog
+        open={endingSoonOpen}
+        ddayLabel={dday.label}
+        endDate={endDateOnly || challenge.end_date}
+        myEndPending={
+          myParticipant ? !myParticipant.submissions.some((s) => s.type === 'end') : undefined
+        }
+        onClose={onCloseEndingSoon}
+        onAuthEnd={onAuthEndMy}
+      />
+    </>
+  );
+}

--- a/burnfat/src/components/ChallengeTabs.tsx
+++ b/burnfat/src/components/ChallengeTabs.tsx
@@ -1,0 +1,35 @@
+import Tabs from '@mui/material/Tabs';
+import Tab from '@mui/material/Tab';
+
+interface ChallengeTabsProps {
+  value: number;
+  onChange: (value: number) => void;
+}
+
+/** Sprint 3 Phase B — ChallengePage 의 sticky 탭 바 (참가자/순위/주간 기록). */
+export default function ChallengeTabs({ value, onChange }: ChallengeTabsProps) {
+  return (
+    <Tabs
+      value={value}
+      onChange={(_, v) => onChange(v)}
+      sx={{
+        px: 2,
+        position: 'sticky',
+        top: 0,
+        zIndex: 10,
+        bgcolor: 'background.default',
+        borderBottom: 1,
+        borderColor: 'divider',
+        '& .MuiTab-root': { minHeight: 48 },
+        '& .MuiTabs-flexContainer': { gap: 0 },
+      }}
+      variant="scrollable"
+      scrollButtons="auto"
+      allowScrollButtonsMobile
+    >
+      <Tab label="참가자 / 인증" />
+      <Tab label="순위" />
+      <Tab label="주간 기록" />
+    </Tabs>
+  );
+}

--- a/burnfat/src/components/ParticipantsTab.tsx
+++ b/burnfat/src/components/ParticipantsTab.tsx
@@ -1,0 +1,235 @@
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Typography from '@mui/material/Typography';
+import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
+import AddIcon from '@mui/icons-material/Add';
+import EditIcon from '@mui/icons-material/Edit';
+import PhotoCameraIcon from '@mui/icons-material/PhotoCamera';
+import type { ParticipantWithSubmissions } from '../types';
+import { resolveImageUrl } from '../lib/signedImage';
+import { EndAuthButton } from '../theme/rankAnimations';
+
+interface ParticipantsTabProps {
+  participants: ParticipantWithSubmissions[];
+  /** 전 참가자의 종료 인증이 끝났는지 — 종료 인증 값 노출 여부를 결정. */
+  allEndComplete: boolean;
+  onAuthStart: (p: ParticipantWithSubmissions) => void;
+  onAuthEnd: (p: ParticipantWithSubmissions) => void;
+  onOpenBasicInfo: (p: ParticipantWithSubmissions) => void;
+  onToast: (msg: string) => void;
+}
+
+// 종료 인증 버튼의 참가자별 글로우 색 — id 해시로 안정적으로 배정.
+const END_BTN_COLORS = [
+  { main: '#16a34a', glow: 'rgba(22, 163, 74, 0.5)' },
+  { main: '#2563eb', glow: 'rgba(37, 99, 235, 0.5)' },
+  { main: '#7c3aed', glow: 'rgba(124, 58, 237, 0.5)' },
+  { main: '#db2777', glow: 'rgba(219, 39, 119, 0.5)' },
+  { main: '#ea580c', glow: 'rgba(234, 88, 12, 0.5)' },
+  { main: '#0891b2', glow: 'rgba(8, 145, 178, 0.5)' },
+  { main: '#059669', glow: 'rgba(5, 150, 105, 0.5)' },
+  { main: '#ca8a04', glow: 'rgba(202, 138, 4, 0.5)' },
+];
+const getEndBtnColor = (participantId: string) => {
+  let hash = 0;
+  for (let i = 0; i < participantId.length; i++)
+    hash = (hash << 5) - hash + participantId.charCodeAt(i);
+  return END_BTN_COLORS[Math.abs(hash) % END_BTN_COLORS.length];
+};
+
+/**
+ * Sprint 3 Phase B — ChallengePage Tab 0 (참가자 / 인증) 의 카드 목록.
+ * 시작 체지방률 내림차순으로 정렬해 인증 진행 상태를 보여 준다.
+ */
+export default function ParticipantsTab({
+  participants,
+  allEndComplete,
+  onAuthStart,
+  onAuthEnd,
+  onOpenBasicInfo,
+  onToast,
+}: ParticipantsTabProps) {
+  const participantsWithRank = [...participants]
+    .map((p) => {
+      const start = p.submissions.find((s) => s.type === 'start');
+      const startBodyFat = start ? Number(start.body_fat_rate) : null;
+      return { ...p, startBodyFat };
+    })
+    .sort((a, b) => {
+      if (a.startBodyFat == null && b.startBodyFat == null) return 0;
+      if (a.startBodyFat == null) return 1;
+      if (b.startBodyFat == null) return -1;
+      return b.startBodyFat - a.startBodyFat;
+    });
+  const topStartBodyFat =
+    participantsWithRank.find((p) => p.startBodyFat != null)?.startBodyFat ?? null;
+
+  return (
+    <Box sx={{ px: 2, pt: 2 }}>
+      {participantsWithRank.map((p, idx) => {
+        const gap =
+          topStartBodyFat != null && p.startBodyFat != null
+            ? topStartBodyFat - p.startBodyFat
+            : null;
+        return (
+          <Card key={p.id} sx={{ mb: 2 }}>
+            <CardContent sx={{ p: 2 }}>
+              <Box
+                sx={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
+                  flexWrap: 'wrap',
+                  gap: 1,
+                }}
+              >
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                  <Typography variant="body2" color="text.secondary" sx={{ minWidth: 24 }}>
+                    {p.startBodyFat != null ? `#${idx + 1}` : '-'}
+                  </Typography>
+                  <Typography fontWeight={600}>{p.nickname}</Typography>
+                  {gap != null && gap > 0 && (
+                    <Typography
+                      variant="caption"
+                      sx={{
+                        color: 'warning.main',
+                        fontWeight: 600,
+                        bgcolor: 'warning.50',
+                        px: 1,
+                        py: 0.25,
+                        borderRadius: 1,
+                      }}
+                    >
+                      1등과 격차 +{gap.toFixed(1)}%p
+                    </Typography>
+                  )}
+                </Box>
+                <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+                  <Tooltip title="기본정보 수정">
+                    <IconButton
+                      size="small"
+                      onClick={() => onOpenBasicInfo(p)}
+                      sx={{ p: 0.5, minWidth: 44, minHeight: 44 }}
+                      aria-label={`${p.nickname} 기본정보 수정`}
+                    >
+                      <EditIcon sx={{ fontSize: 18 }} />
+                    </IconButton>
+                  </Tooltip>
+                  {!p.submissions.some((s) => s.type === 'start') && (
+                    <Button
+                      size="small"
+                      variant="outlined"
+                      startIcon={<AddIcon sx={{ fontSize: 16 }} />}
+                      onClick={() => onAuthStart(p)}
+                      sx={{ minHeight: 44, py: 0.75, px: 1.5, fontSize: '0.8125rem' }}
+                    >
+                      시작일 인증
+                    </Button>
+                  )}
+                  {!p.submissions.some((s) => s.type === 'end') &&
+                    (() => {
+                      const { main, glow } = getEndBtnColor(p.id);
+                      const glowDim = glow.replace('0.5)', '0.4)');
+                      return (
+                        <EndAuthButton
+                          size="small"
+                          variant="outlined"
+                          startIcon={<AddIcon sx={{ fontSize: 16 }} />}
+                          onClick={() => onAuthEnd(p)}
+                          glowMain={main}
+                          glow={glow}
+                          glowDim={glowDim}
+                        >
+                          종료일 인증
+                        </EndAuthButton>
+                      );
+                    })()}
+                </Box>
+              </Box>
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5, mt: 1 }}>
+                {[...p.submissions]
+                  .sort((a, b) => (a.type === 'start' ? 0 : 1) - (b.type === 'start' ? 0 : 1))
+                  .map((s) => {
+                    if (s.type === 'end' && !allEndComplete) {
+                      return (
+                        <Box
+                          key={s.id}
+                          sx={{
+                            display: 'flex',
+                            justifyContent: 'space-between',
+                            alignItems: 'center',
+                          }}
+                        >
+                          <Typography variant="body2" color="text.secondary">
+                            종료: <span style={{ opacity: 0.7 }}>인증 완료</span>
+                          </Typography>
+                        </Box>
+                      );
+                    }
+                    return (
+                      <Box
+                        key={s.id}
+                        sx={{
+                          display: 'flex',
+                          justifyContent: 'space-between',
+                          alignItems: 'center',
+                          gap: 1,
+                        }}
+                      >
+                        <Typography
+                          variant="body2"
+                          color="text.secondary"
+                          sx={{ flex: '1 1 auto', minWidth: 0 }}
+                        >
+                          {s.type === 'start' ? '시작' : '종료'}: 체지방률{' '}
+                          <strong>{Number(s.body_fat_rate).toFixed(1)}%</strong>
+                        </Typography>
+                        {s.image_url ? (
+                          <Tooltip title="탭하여 이미지 보기">
+                            <Button
+                              size="small"
+                              variant="outlined"
+                              color="primary"
+                              startIcon={<PhotoCameraIcon sx={{ fontSize: 14 }} />}
+                              sx={{
+                                minHeight: 28,
+                                minWidth: 40,
+                                py: 0.25,
+                                px: 0.75,
+                                fontSize: '0.75rem',
+                                flexShrink: 0,
+                              }}
+                              aria-label="인증 이미지 보기"
+                              onClick={async () => {
+                                // Sprint 0.3: storage path → signed URL (7일)
+                                const url = await resolveImageUrl(s.image_url);
+                                if (!url) {
+                                  onToast('이미지를 불러오지 못했습니다.');
+                                  return;
+                                }
+                                window.open(url, '_blank', 'noopener,noreferrer');
+                              }}
+                            >
+                              보기
+                            </Button>
+                          </Tooltip>
+                        ) : null}
+                      </Box>
+                    );
+                  })}
+              </Box>
+            </CardContent>
+          </Card>
+        );
+      })}
+      {participants.length === 0 && (
+        <Typography color="text.secondary" sx={{ textAlign: 'center', py: 4 }}>
+          아직 참가자가 없습니다. 위에서 닉네임을 입력해 참가하세요.
+        </Typography>
+      )}
+    </Box>
+  );
+}

--- a/burnfat/src/components/ParticipantsTabHeader.tsx
+++ b/burnfat/src/components/ParticipantsTabHeader.tsx
@@ -1,0 +1,149 @@
+import { useState } from 'react';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import { supabase } from '../lib/supabase';
+import type { Challenge, ParticipantWithSubmissions, WeeklyLog } from '../types';
+import MyStatusCard from './MyStatusCard';
+
+interface ParticipantsTabHeaderProps {
+  challenge: Challenge;
+  /** 이 디바이스에서 식별된 "나". null 이면 참가 폼만 노출. */
+  myParticipant: ParticipantWithSubmissions | null;
+  myLogs: WeeklyLog[];
+  onAuthStart: (p: ParticipantWithSubmissions) => void;
+  onAuthEnd: (p: ParticipantWithSubmissions) => void;
+  onOpenWeeklyLog: (p: ParticipantWithSubmissions, weekNo?: number) => void;
+  onForget: () => void;
+  /** 참가 직후 이 디바이스의 "나" 로 기억. */
+  onRemember: (participantId: string) => void;
+  /** 참가 직후 기본정보 입력 다이얼로그 진입. */
+  onJoined: (p: ParticipantWithSubmissions) => void;
+  onRefetch: () => void;
+}
+
+/**
+ * Sprint 3 Phase B — ChallengePage Tab 0 의 *탭 바 위* 영역.
+ * 식별된 "나" 가 있으면 개인 상태 카드, 없으면(또는 추가 시) 참가 폼을 보여 준다.
+ * (탭 바 아래 참가자 카드 목록은 ParticipantsTab 이 담당.)
+ */
+export default function ParticipantsTabHeader({
+  challenge,
+  myParticipant,
+  myLogs,
+  onAuthStart,
+  onAuthEnd,
+  onOpenWeeklyLog,
+  onForget,
+  onRemember,
+  onJoined,
+  onRefetch,
+}: ParticipantsTabHeaderProps) {
+  const [showJoinForm, setShowJoinForm] = useState(false);
+  const [joinNickname, setJoinNickname] = useState('');
+  const [joinLoading, setJoinLoading] = useState(false);
+  const [joinError, setJoinError] = useState('');
+
+  const handleJoin = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!joinNickname.trim()) return;
+    setJoinLoading(true);
+    const { data: newParticipant, error: err } = await supabase
+      .from('participants')
+      .insert({ challenge_id: challenge.id, nickname: joinNickname.trim() })
+      .select()
+      .single();
+    setJoinLoading(false);
+    if (err) {
+      setJoinError(
+        err.message.includes('unique') ? '이미 등록된 닉네임입니다.' : err.message
+      );
+      return;
+    }
+    setJoinError('');
+    setJoinNickname('');
+    onRefetch();
+    const joined = { ...(newParticipant as ParticipantWithSubmissions), submissions: [] };
+    // Sprint 1: 방금 등록한 참가자를 이 디바이스의 "나" 로 기억.
+    onRemember(joined.id);
+    setShowJoinForm(false);
+    onJoined(joined);
+  };
+
+  if (myParticipant && !showJoinForm) {
+    return (
+      <>
+        <MyStatusCard
+          participant={myParticipant}
+          logs={myLogs}
+          challengeStartDate={challenge.start_date}
+          challengeEndDate={challenge.end_date}
+          onAuthStart={() => onAuthStart(myParticipant)}
+          onAuthEnd={() => onAuthEnd(myParticipant)}
+          onOpenWeeklyLog={(weekNo) => onOpenWeeklyLog(myParticipant, weekNo)}
+          onForget={onForget}
+        />
+        <Box sx={{ px: 2, mb: 1, textAlign: 'center' }}>
+          <Button size="small" variant="text" onClick={() => setShowJoinForm(true)}>
+            + 다른 참가자 추가
+          </Button>
+        </Box>
+      </>
+    );
+  }
+
+  return (
+    <Card sx={{ mx: 2, mb: 2 }}>
+      <CardContent sx={{ p: 2 }}>
+        <Box
+          sx={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            mb: 0.5,
+          }}
+        >
+          <Typography variant="subtitle2" color="text.secondary">
+            참가하기
+          </Typography>
+          {myParticipant && (
+            <Button
+              size="small"
+              variant="text"
+              color="inherit"
+              onClick={() => setShowJoinForm(false)}
+            >
+              취소
+            </Button>
+          )}
+        </Box>
+        <form onSubmit={handleJoin} style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+          <TextField
+            size="small"
+            placeholder="닉네임"
+            value={joinNickname}
+            onChange={(e) => setJoinNickname(e.target.value)}
+            sx={{ flex: 1, minWidth: 0, '& .MuiInputBase-root': { minHeight: 40 } }}
+          />
+          <Button
+            type="submit"
+            variant="contained"
+            size="small"
+            disabled={joinLoading || !joinNickname.trim()}
+            sx={{ minWidth: 80, minHeight: 40 }}
+          >
+            참가
+          </Button>
+        </form>
+        {joinError && (
+          <Typography color="error" variant="caption" sx={{ mt: 1, display: 'block' }}>
+            {joinError}
+          </Typography>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/burnfat/src/components/RankingTab.tsx
+++ b/burnfat/src/components/RankingTab.tsx
@@ -1,0 +1,261 @@
+import { useState } from 'react';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import Paper from '@mui/material/Paper';
+import Tooltip from '@mui/material/Tooltip';
+import ShareIcon from '@mui/icons-material/Share';
+import LockOpenIcon from '@mui/icons-material/LockOpen';
+import LockIcon from '@mui/icons-material/Lock';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import type { Challenge, ParticipantWithSubmissions, RankingRow } from '../types';
+import { RankOneRow, RankMedal } from '../theme/rankAnimations';
+import RankingShareDialog from './RankingShareDialog';
+
+// Sprint 0.4: 디버그 플래그 — 운영 빌드에서는 미설정/"false".
+const DEBUG_SHOW_RANKING =
+  (import.meta.env.VITE_DEBUG_SHOW_RANKING ?? '').toLowerCase() === 'true';
+
+interface RankingTabProps {
+  ranking: RankingRow[];
+  participants: ParticipantWithSubmissions[];
+  challenge: Challenge;
+  /** 결과 공유 카드용 대결 URL. */
+  shareUrl: string;
+  /** 중간 순위 공개/잠금 토글 (PIN 게이팅은 호출 측에서 처리). */
+  onUnlockRanking: () => void;
+  onToast: (msg: string) => void;
+}
+
+/**
+ * Sprint 3 Phase B — ChallengePage Tab 1 (순위).
+ * 종료 인증 진행 상태 + 중간 공개 토글 + 체지방 감소율 순위표.
+ */
+export default function RankingTab({
+  ranking,
+  participants,
+  challenge,
+  shareUrl,
+  onUnlockRanking,
+  onToast,
+}: RankingTabProps) {
+  const [shareOpen, setShareOpen] = useState(false);
+  const participantsWithStart = participants.filter((p) =>
+    p.submissions.some((s) => s.type === 'start')
+  );
+  const allEndComplete =
+    participantsWithStart.length > 0 &&
+    participantsWithStart.every((p) => p.submissions.some((s) => s.type === 'end'));
+  const showRanking =
+    allEndComplete || (challenge.ranking_unlocked ?? false) || DEBUG_SHOW_RANKING;
+
+  return (
+    <Box sx={{ px: 2, pt: 2 }}>
+      {/* 종료 인증 진행 상태 + 중간 순위 공개 토글 */}
+      {!allEndComplete && (
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            gap: 1,
+            mb: 2,
+            p: 1.5,
+            bgcolor: showRanking ? 'warning.50' : 'grey.50',
+            borderRadius: 1.5,
+            border: '1px solid',
+            borderColor: showRanking ? 'warning.200' : 'grey.200',
+          }}
+        >
+          <Box>
+            <Typography variant="body2" fontWeight={500}>
+              종료 인증{' '}
+              {participantsWithStart.filter((p) =>
+                p.submissions.some((s) => s.type === 'end')
+              ).length}{' '}
+              / {participantsWithStart.length}명 완료
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              {showRanking ? '현재 중간 순위 공개 중' : '전원 완료 시 자동 공개'}
+            </Typography>
+          </Box>
+          <Button
+            variant={showRanking ? 'contained' : 'outlined'}
+            size="small"
+            startIcon={showRanking ? <LockIcon /> : <LockOpenIcon />}
+            onClick={onUnlockRanking}
+            color="warning"
+            sx={{ flexShrink: 0 }}
+          >
+            {showRanking ? '순위 잠금' : '중간 공개'}
+            {challenge.has_admin_pin && (
+              <LockIcon sx={{ fontSize: 12, ml: 0.5, opacity: 0.6 }} />
+            )}
+          </Button>
+        </Box>
+      )}
+      {!showRanking ? (
+        <Typography color="text.secondary" sx={{ textAlign: 'center', py: 6 }}>
+          종료 인증이 완료되면 순위가 공개됩니다.
+        </Typography>
+      ) : ranking.length === 0 ? (
+        <Typography color="text.secondary" sx={{ textAlign: 'center', py: 4 }}>
+          시작·종료 인증을 모두 마친 참가자가 있을 때 순위가 표시됩니다.
+        </Typography>
+      ) : (
+        <>
+          <Box
+            sx={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'flex-start',
+              mb: 2,
+              gap: 1,
+            }}
+          >
+            <Box
+              sx={{
+                p: 1.5,
+                bgcolor: 'grey.50',
+                borderRadius: 1.5,
+                border: '1px solid',
+                borderColor: 'grey.200',
+                flex: 1,
+              }}
+            >
+              <Typography variant="caption" color="text.secondary">
+                💡 감소율 = (시작 − 종료) ÷ 시작 × 100
+              </Typography>
+              <Typography
+                variant="caption"
+                color="text.secondary"
+                display="block"
+                sx={{ mt: 0.25 }}
+              >
+                시작 체지방에 관계없이 공정하게 비교하는 상대 감소율입니다.
+              </Typography>
+            </Box>
+            <Button
+              variant="outlined"
+              size="small"
+              startIcon={<ShareIcon />}
+              onClick={() => setShareOpen(true)}
+              sx={{ flexShrink: 0, minHeight: 44 }}
+            >
+              결과 공유
+            </Button>
+          </Box>
+          <TableContainer component={Paper} sx={{ borderRadius: 2 }}>
+            <Table size="small" sx={{ tableLayout: 'fixed', width: '100%' }}>
+              <TableHead>
+                <TableRow>
+                  <TableCell sx={{ width: 64, whiteSpace: 'nowrap' }}>순위</TableCell>
+                  <TableCell>닉네임</TableCell>
+                  <TableCell align="right" sx={{ width: 64 }}>
+                    시작
+                  </TableCell>
+                  <TableCell align="right" sx={{ width: 64 }}>
+                    종료
+                  </TableCell>
+                  <TableCell align="right" sx={{ width: 80 }}>
+                    <Tooltip title="감소율 = (시작 − 종료) ÷ 시작 × 100" arrow>
+                      <Box
+                        sx={{
+                          display: 'inline-flex',
+                          alignItems: 'center',
+                          gap: 0.5,
+                          cursor: 'help',
+                        }}
+                      >
+                        감소율
+                        <InfoOutlinedIcon sx={{ fontSize: 13, opacity: 0.55 }} />
+                      </Box>
+                    </Tooltip>
+                  </TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {ranking.map((r) => {
+                  const medal =
+                    r.rank === 1 ? '🥇' : r.rank === 2 ? '🥈' : r.rank === 3 ? '🥉' : null;
+                  const isFirst = r.rank === 1;
+                  const RowComp = isFirst ? RankOneRow : TableRow;
+                  return (
+                    <RowComp
+                      key={r.nickname}
+                      sx={!isFirst && r.rank <= 3 ? { bgcolor: 'success.50' } : undefined}
+                    >
+                      <TableCell sx={{ width: 64, verticalAlign: 'middle' }}>
+                        {medal ? (
+                          <RankMedal role="img" aria-label={`${r.rank}위`} twinkle={isFirst}>
+                            {medal}
+                          </RankMedal>
+                        ) : (
+                          r.rank
+                        )}
+                      </TableCell>
+                      <TableCell
+                        sx={{
+                          fontWeight: r.rank === 1 ? 700 : 400,
+                          color: isFirst ? '#92400e' : 'inherit',
+                          verticalAlign: 'middle',
+                          overflow: 'hidden',
+                        }}
+                      >
+                        <Box
+                          sx={{
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            whiteSpace: 'nowrap',
+                          }}
+                        >
+                          {r.nickname}
+                        </Box>
+                      </TableCell>
+                      <TableCell align="right" sx={{ verticalAlign: 'middle' }}>
+                        {r.startBodyFat.toFixed(1)}%
+                      </TableCell>
+                      <TableCell align="right" sx={{ verticalAlign: 'middle' }}>
+                        {r.endBodyFat.toFixed(1)}%
+                      </TableCell>
+                      <TableCell align="right" sx={{ verticalAlign: 'middle' }}>
+                        <Typography
+                          component="span"
+                          sx={{
+                            color: isFirst ? '#b45309' : 'success.main',
+                            fontWeight: isFirst ? 700 : 600,
+                            textShadow: isFirst ? '0 0 8px rgba(245, 158, 11, 0.5)' : 'none',
+                          }}
+                        >
+                          -{r.reductionRate.toFixed(2)}%
+                        </Typography>
+                      </TableCell>
+                    </RowComp>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </>
+      )}
+      {/* Sprint 1: 랭킹 공유 (PNG + 텍스트) */}
+      {shareOpen && (
+        <RankingShareDialog
+          open={shareOpen}
+          challenge={challenge}
+          ranking={ranking}
+          participantCount={participants.length}
+          shareUrl={shareUrl}
+          onClose={() => setShareOpen(false)}
+          onToast={onToast}
+        />
+      )}
+    </Box>
+  );
+}

--- a/burnfat/src/components/WeeklyLogsTab.tsx
+++ b/burnfat/src/components/WeeklyLogsTab.tsx
@@ -1,0 +1,98 @@
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import type { Challenge, ParticipantWithSubmissions, WeeklyLog } from '../types';
+import type { useRecordStatus } from '../hooks/useRecordStatus';
+import AllParticipantsChart from './AllParticipantsChart';
+import RecordStatusSummary from './RecordStatusSummary';
+import ParticipantWeeklyLogCard from './ParticipantWeeklyLogCard';
+import GoalProgressWidget from './GoalProgressWidget';
+
+interface WeeklyLogsTabProps {
+  challenge: Challenge;
+  participants: ParticipantWithSubmissions[];
+  logsByParticipant: Record<string, WeeklyLog[]>;
+  recordStatus: ReturnType<typeof useRecordStatus>;
+  /** 이 디바이스에서 식별된 "나" — 목표 진행률 위젯 표시 대상. */
+  myParticipant: ParticipantWithSubmissions | null;
+  onOpenLogForm: (p: ParticipantWithSubmissions, weekNo?: number) => void;
+  onOpenBasicInfo: (p: ParticipantWithSubmissions) => void;
+  onRefresh: () => void;
+}
+
+/**
+ * Sprint 3 Phase B — ChallengePage Tab 2 (주간 기록).
+ * 목표 진행률 + 입력 현황 요약 + 전체 추이 차트 + 참가자별 기록 카드.
+ */
+export default function WeeklyLogsTab({
+  challenge,
+  participants,
+  logsByParticipant,
+  recordStatus,
+  myParticipant,
+  onOpenLogForm,
+  onOpenBasicInfo,
+  onRefresh,
+}: WeeklyLogsTabProps) {
+  return (
+    <Box sx={{ px: 2, pt: 2 }}>
+      <Box
+        sx={{
+          mb: 2,
+          p: 2,
+          bgcolor: 'primary.50',
+          borderRadius: 2,
+          border: '1px solid',
+          borderColor: 'primary.200',
+        }}
+      >
+        <Typography variant="body2" color="primary.dark" fontWeight={500}>
+          대결방 참가자 누구나 서로의 기록을 입력·확인할 수 있습니다.
+        </Typography>
+        <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
+          개인 락 없음 · 공동 입력 · 공동 확인
+        </Typography>
+      </Box>
+      {/* Sprint 2: 목표 진행률 위젯 — 식별된 "나" 에 대해 상단 고정 */}
+      {myParticipant && (
+        <GoalProgressWidget
+          participant={myParticipant}
+          logs={logsByParticipant[myParticipant.id] || []}
+          onOpenBasicInfo={() => onOpenBasicInfo(myParticipant)}
+        />
+      )}
+      <RecordStatusSummary
+        currentWeek={recordStatus.currentWeek}
+        completedCount={recordStatus.completedCount}
+        notCompletedCount={recordStatus.notCompletedCount}
+        notCompleted={recordStatus.notCompleted}
+        cumulativeFillRate={recordStatus.cumulativeFillRate}
+        totalFilledCells={recordStatus.totalFilledCells}
+        totalPossibleCells={recordStatus.totalPossibleCells}
+      />
+      <Typography variant="subtitle2" sx={{ mb: 1 }}>
+        전체 참가자 추이
+      </Typography>
+      <AllParticipantsChart participants={participants} logsByParticipant={logsByParticipant} />
+      <Typography variant="subtitle2" sx={{ mt: 3, mb: 1 }}>
+        참가자별 상세
+      </Typography>
+      {participants.map((p) => (
+        <ParticipantWeeklyLogCard
+          key={p.id}
+          participant={p}
+          challengeStartDate={challenge.start_date}
+          challengeEndDate={challenge.end_date}
+          logs={logsByParticipant[p.id] || []}
+          onOpenLogForm={(weekNo) => onOpenLogForm(p, weekNo)}
+          onOpenBasicInfo={() => onOpenBasicInfo(p)}
+          onRefresh={onRefresh}
+        />
+      ))}
+      {participants.length === 0 && (
+        <Typography color="text.secondary" sx={{ textAlign: 'center', py: 4 }}>
+          아직 참가자가 없습니다. 위에서 닉네임을 입력해 참가하세요.
+        </Typography>
+      )}
+    </Box>
+  );
+}

--- a/burnfat/src/hooks/__tests__/useAIAdvice.test.ts
+++ b/burnfat/src/hooks/__tests__/useAIAdvice.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import type { AIAdviceResponse } from '../../lib/edgeFunctions';
+
+vi.mock('../../lib/edgeFunctions', () => ({
+  fetchAIAdvice: vi.fn(),
+}));
+
+import { fetchAIAdvice } from '../../lib/edgeFunctions';
+import { useAIAdvice } from '../useAIAdvice';
+
+const fetchMock = fetchAIAdvice as unknown as ReturnType<typeof vi.fn>;
+
+function response(partial: Partial<AIAdviceResponse>): AIAdviceResponse {
+  return {
+    advice: '조언 본문',
+    structured: null,
+    cached: false,
+    weekNo: 2,
+    ...partial,
+  };
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+});
+
+describe('useAIAdvice', () => {
+  it('cache miss — result.cached 가 false 로 채워진다', async () => {
+    fetchMock.mockResolvedValue(response({ cached: false }));
+
+    const { result } = renderHook(() => useAIAdvice());
+    await act(async () => {
+      await result.current.load('p1');
+    });
+
+    expect(result.current.result?.cached).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(fetchMock).toHaveBeenCalledWith({ participantId: 'p1', forceRefresh: false });
+  });
+
+  it('cache hit — result.cached 가 true', async () => {
+    fetchMock.mockResolvedValue(response({ cached: true }));
+
+    const { result } = renderHook(() => useAIAdvice());
+    await act(async () => {
+      await result.current.load('p1');
+    });
+
+    expect(result.current.result?.cached).toBe(true);
+  });
+
+  it('forceRefresh=true 면 fetchAIAdvice 에 forceRefresh 가 전달된다', async () => {
+    fetchMock.mockResolvedValue(response({ cached: false }));
+
+    const { result } = renderHook(() => useAIAdvice());
+    await act(async () => {
+      await result.current.load('p1', true);
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith({ participantId: 'p1', forceRefresh: true });
+  });
+
+  it('fetchAIAdvice 가 throw 하면 error 가 설정되고 result 는 null', async () => {
+    fetchMock.mockRejectedValue(new Error('서버 오류'));
+
+    const { result } = renderHook(() => useAIAdvice());
+    await act(async () => {
+      await result.current.load('p1');
+    });
+
+    await waitFor(() => expect(result.current.error).toBe('서버 오류'));
+    expect(result.current.result).toBeNull();
+  });
+});

--- a/burnfat/src/hooks/__tests__/useCoachSession.test.ts
+++ b/burnfat/src/hooks/__tests__/useCoachSession.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import type { CoachMessage } from '../../types';
+import type { CoachSessionPreview } from '../../lib/coachClient';
+
+vi.mock('../../lib/coachClient', () => ({
+  fetchCoachSessions: vi.fn(),
+  fetchCoachSessionMessages: vi.fn(),
+  streamCoachMessage: vi.fn(),
+  endCoachSession: vi.fn(),
+  resetCoachMemory: vi.fn(),
+  stripRefMarkers: (s: string) => s,
+}));
+
+import {
+  fetchCoachSessions,
+  fetchCoachSessionMessages,
+  streamCoachMessage,
+} from '../../lib/coachClient';
+import { useCoachSession } from '../useCoachSession';
+
+const sessionsMock = fetchCoachSessions as unknown as ReturnType<typeof vi.fn>;
+const messagesMock = fetchCoachSessionMessages as unknown as ReturnType<typeof vi.fn>;
+const streamMock = streamCoachMessage as unknown as ReturnType<typeof vi.fn>;
+
+function preview(partial: Partial<CoachSessionPreview>): CoachSessionPreview {
+  return {
+    id: 's1',
+    week_no: 2,
+    persona: 'friendly',
+    status: 'active',
+    visibility: 'private',
+    created_at: '2026-05-25',
+    updated_at: '2026-05-25',
+    preview: '',
+    owned: true,
+    ...partial,
+  };
+}
+
+function msg(partial: Partial<CoachMessage>): CoachMessage {
+  return {
+    id: 'm1',
+    session_id: 's1',
+    role: 'assistant',
+    content: '메시지',
+    tokens_in: null,
+    tokens_out: null,
+    references_jsonb: null,
+    created_at: '2026-05-25',
+    ...partial,
+  };
+}
+
+const params = { participantId: 'p1', weekNo: 2, seedContent: '시드 조언', open: true };
+
+beforeEach(() => {
+  sessionsMock.mockReset();
+  messagesMock.mockReset();
+  streamMock.mockReset();
+});
+
+describe('useCoachSession', () => {
+  it('활성 세션이 있으면 메시지를 복원하고 system 역할은 제외한다', async () => {
+    sessionsMock.mockResolvedValue([preview({ id: 's1' })]);
+    messagesMock.mockResolvedValue({
+      session: {},
+      messages: [
+        msg({ id: 'sys', role: 'system', content: '시스템' }),
+        msg({ id: 'a1', role: 'assistant', content: '안녕하세요' }),
+        msg({
+          id: 'a2',
+          role: 'assistant',
+          content: '지난 주 기록을 보면',
+          references_jsonb: [{ week_no: 1 }],
+        }),
+      ],
+    });
+
+    const { result } = renderHook(() => useCoachSession(params));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.sessionId).toBe('s1');
+    // system 메시지는 제외 → 2개
+    expect(result.current.messages).toHaveLength(2);
+    // references_jsonb 가 references 로 매핑된다 (메모리 인용 분기)
+    const cited = result.current.messages.find((m) => m.id === 'a2');
+    expect(cited?.references).toEqual([{ week_no: 1 }]);
+  });
+
+  it('활성 세션이 없으면 시드 메시지 한 개로 시작한다', async () => {
+    sessionsMock.mockResolvedValue([]);
+
+    const { result } = renderHook(() => useCoachSession(params));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.sessionId).toBeNull();
+    expect(result.current.messages).toHaveLength(1);
+    expect(result.current.messages[0].content).toBe('시드 조언');
+  });
+
+  it('send 는 사용자 메시지를 추가하고 onDone 시 어시스턴트 메시지를 붙인다', async () => {
+    sessionsMock.mockResolvedValue([]);
+    streamMock.mockImplementation(
+      async (
+        _req: unknown,
+        handlers: {
+          onStart?: (i: {
+            sessionId: string;
+            sessionCreated: boolean;
+            weekMessagesUsed: number;
+            weekMessagesLimit: number;
+          }) => void;
+          onDone: (i: { message: CoachMessage | null }) => void;
+        }
+      ) => {
+        handlers.onStart?.({
+          sessionId: 's-new',
+          sessionCreated: true,
+          weekMessagesUsed: 1,
+          weekMessagesLimit: 30,
+        });
+        handlers.onDone({ message: msg({ id: 'a-reply', content: '좋은 질문이에요' }) });
+      }
+    );
+
+    const { result } = renderHook(() => useCoachSession(params));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.send('이번 주 어때요?');
+    });
+
+    expect(streamMock).toHaveBeenCalledTimes(1);
+    const contents = result.current.messages.map((m) => m.content);
+    expect(contents).toContain('이번 주 어때요?');
+    expect(contents).toContain('좋은 질문이에요');
+    expect(result.current.sessionId).toBe('s-new');
+    expect(result.current.sending).toBe(false);
+  });
+});

--- a/burnfat/src/hooks/__tests__/useRecordStatus.test.ts
+++ b/burnfat/src/hooks/__tests__/useRecordStatus.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useRecordStatus } from '../useRecordStatus';
+import type { ParticipantWithSubmissions, WeeklyLog } from '../../types';
+
+// getCurrentWeekNo 가 new Date() 에 의존하므로 "오늘" 을 고정한다.
+beforeAll(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-06-01T00:00:00Z'));
+});
+afterAll(() => {
+  vi.useRealTimers();
+});
+
+function participant(id: string, nickname: string): ParticipantWithSubmissions {
+  return {
+    id,
+    challenge_id: 'c1',
+    nickname,
+    age: null,
+    gender: null,
+    height_cm: null,
+    target_body_fat: null,
+    created_at: '2026-05-01',
+    submissions: [],
+  };
+}
+
+function log(participantId: string, weekNo: number): WeeklyLog {
+  return {
+    id: `${participantId}-w${weekNo}`,
+    participant_id: participantId,
+    week_no: weekNo,
+    recorded_at: '2026-05-25',
+    age: null,
+    gender: null,
+    weight_kg: null,
+    height_cm: null,
+    body_fat_rate: null,
+    exercise_count: null,
+    sleep_hours: null,
+    diet_quality: null,
+    note: null,
+    created_at: '2026-05-25',
+    updated_at: '2026-05-25',
+  };
+}
+
+describe('useRecordStatus', () => {
+  it('참가자가 없으면 모든 카운트가 0, fillRate 0', () => {
+    const { result } = renderHook(() =>
+      useRecordStatus([], {}, '2026-05-25')
+    );
+    expect(result.current.completedCount).toBe(0);
+    expect(result.current.notCompletedCount).toBe(0);
+    expect(result.current.cumulativeFillRate).toBe(0);
+    expect(result.current.totalPossibleCells).toBe(0);
+  });
+
+  it('시작일 7일 전이면 currentWeek 는 2', () => {
+    const { result } = renderHook(() =>
+      useRecordStatus([participant('p1', 'A')], {}, '2026-05-25')
+    );
+    expect(result.current.currentWeek).toBe(2);
+  });
+
+  it('시작 당일이면 currentWeek 는 1', () => {
+    const { result } = renderHook(() =>
+      useRecordStatus([participant('p1', 'A')], {}, '2026-06-01')
+    );
+    expect(result.current.currentWeek).toBe(1);
+  });
+
+  it('현재 주차 로그 유무로 completed / notCompleted 를 분류한다', () => {
+    const parts = [participant('p1', 'A'), participant('p2', 'B')];
+    const logs = { p1: [log('p1', 2)], p2: [log('p2', 1)] };
+    const { result } = renderHook(() =>
+      useRecordStatus(parts, logs, '2026-05-25')
+    );
+    // currentWeek = 2 → p1 만 완료
+    expect(result.current.completedCount).toBe(1);
+    expect(result.current.notCompletedCount).toBe(1);
+    expect(result.current.notCompleted.map((p) => p.nickname)).toEqual(['B']);
+  });
+
+  it('누적 입력률 = 입력 셀 / (참가자수 × currentWeek)', () => {
+    const parts = [participant('p1', 'A'), participant('p2', 'B')];
+    // currentWeek = 2, totalPossible = 2 × 2 = 4
+    // p1: week1,2 입력(2) / p2: week1 입력(1) → filled 3 → 75%
+    const logs = {
+      p1: [log('p1', 1), log('p1', 2)],
+      p2: [log('p2', 1)],
+    };
+    const { result } = renderHook(() =>
+      useRecordStatus(parts, logs, '2026-05-25')
+    );
+    expect(result.current.totalPossibleCells).toBe(4);
+    expect(result.current.totalFilledCells).toBe(3);
+    expect(result.current.cumulativeFillRate).toBe(75);
+  });
+
+  it('currentWeek 초과 주차 로그는 누적 셀 계산에서 제외된다', () => {
+    const parts = [participant('p1', 'A')];
+    // currentWeek = 2 인데 week3 로그가 있어도 filled 에 포함 안 됨
+    const logs = { p1: [log('p1', 1), log('p1', 3)] };
+    const { result } = renderHook(() =>
+      useRecordStatus(parts, logs, '2026-05-25')
+    );
+    expect(result.current.totalFilledCells).toBe(1);
+  });
+
+  it('전원이 현재 주차를 입력하면 notCompleted 가 비어 있다', () => {
+    const parts = [participant('p1', 'A'), participant('p2', 'B')];
+    const logs = { p1: [log('p1', 2)], p2: [log('p2', 2)] };
+    const { result } = renderHook(() =>
+      useRecordStatus(parts, logs, '2026-05-25')
+    );
+    expect(result.current.completedCount).toBe(2);
+    expect(result.current.notCompleted).toEqual([]);
+  });
+});

--- a/burnfat/src/hooks/__tests__/useWeeklyLogs.test.ts
+++ b/burnfat/src/hooks/__tests__/useWeeklyLogs.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import type { WeeklyLog } from '../../types';
+
+// supabase 클라이언트 mock — fetch / insert 체인을 테스트별로 주입.
+vi.mock('../../lib/supabase', () => ({
+  supabase: { from: vi.fn() },
+}));
+
+import { supabase } from '../../lib/supabase';
+import { useWeeklyLogs } from '../useWeeklyLogs';
+
+const fromMock = supabase.from as unknown as ReturnType<typeof vi.fn>;
+
+function makeLog(weekNo: number): WeeklyLog {
+  return {
+    id: `w${weekNo}`,
+    participant_id: 'p1',
+    week_no: weekNo,
+    recorded_at: '2026-05-25',
+    age: null,
+    gender: null,
+    weight_kg: null,
+    height_cm: null,
+    body_fat_rate: null,
+    exercise_count: null,
+    sleep_hours: null,
+    diet_quality: null,
+    note: null,
+    created_at: '2026-05-25',
+    updated_at: '2026-05-25',
+  };
+}
+
+beforeEach(() => {
+  fromMock.mockReset();
+});
+
+describe('useWeeklyLogs', () => {
+  it('participantId 가 있으면 weekly_logs 를 fetch 해 logs 에 채운다', async () => {
+    const rows = [makeLog(1), makeLog(2)];
+    fromMock.mockReturnValue({
+      select: () => ({ eq: () => ({ order: () => Promise.resolve({ data: rows }) }) }),
+    });
+
+    const { result } = renderHook(() => useWeeklyLogs('p1'));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.logs).toHaveLength(2);
+    expect(result.current.logs[0].week_no).toBe(1);
+    expect(fromMock).toHaveBeenCalledWith('weekly_logs');
+  });
+
+  it('participantId 가 null 이면 fetch 없이 빈 배열', async () => {
+    const { result } = renderHook(() => useWeeklyLogs(null));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.logs).toEqual([]);
+    expect(fromMock).not.toHaveBeenCalled();
+  });
+
+  it('insert 는 supabase.insert 를 호출하고 새 행을 반환한다', async () => {
+    const inserted = makeLog(3);
+    const insertFn = vi.fn(() => ({
+      select: () => ({ single: () => Promise.resolve({ data: inserted, error: null }) }),
+    }));
+    fromMock.mockReturnValue({
+      select: () => ({ eq: () => ({ order: () => Promise.resolve({ data: [] }) }) }),
+      insert: insertFn,
+    });
+
+    const { result } = renderHook(() => useWeeklyLogs('p1'));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    let returned: WeeklyLog | undefined;
+    await act(async () => {
+      returned = await result.current.insert({
+        participant_id: 'p1',
+        week_no: 3,
+      } as Omit<WeeklyLog, 'id' | 'created_at' | 'updated_at'>);
+    });
+
+    expect(insertFn).toHaveBeenCalledTimes(1);
+    expect(returned?.week_no).toBe(3);
+  });
+});

--- a/burnfat/src/hooks/useChallengeData.ts
+++ b/burnfat/src/hooks/useChallengeData.ts
@@ -1,0 +1,142 @@
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { supabase } from '../lib/supabase';
+import type { Challenge, ParticipantWithSubmissions, RankingRow } from '../types';
+import { useAllWeeklyLogsForChallenge } from './useWeeklyLogs';
+
+/**
+ * Sprint 3 Phase B — ChallengePage 의 데이터 페치를 한 곳으로 통합한 hook.
+ *
+ * 진입 시 REST 호출은 정확히 3건:
+ *   1. `challenges_public`  — code 로 챌린지 1건
+ *   2. `participants` + `submissions(*)` 임베드 — 참가자별 인증을 *한 번에* (N+1 제거)
+ *   3. `weekly_logs` `.in(participant_id, …)` — 전 참가자 주간 기록 (useAllWeeklyLogsForChallenge)
+ *
+ * 기존 fetchParticipants 는 참가자마다 submissions 를 개별 SELECT 해 1+N 호출이었다.
+ * Supabase 임베드 쿼리로 1회 호출로 줄였다 (동작·정렬·랭킹 계산은 동일).
+ */
+
+/** 시작/종료 인증을 모두 마친 참가자들로 체지방 감소율 랭킹을 만든다. */
+function computeRanking(participants: ParticipantWithSubmissions[]): RankingRow[] {
+  return participants
+    .map((p) => {
+      const start = p.submissions.find((s) => s.type === 'start');
+      const end = p.submissions.find((s) => s.type === 'end');
+      if (!start || !end) return null;
+      const startVal = Number(start.body_fat_rate);
+      const endVal = Number(end.body_fat_rate);
+      // (시작 - 종료) / 시작 × 100 → 시작 체지방 대비 상대 감소율
+      const reductionRate =
+        startVal > 0 ? Math.round(((startVal - endVal) / startVal) * 10000) / 100 : 0;
+      return {
+        rank: 0,
+        nickname: p.nickname,
+        startBodyFat: Math.round(startVal * 10) / 10,
+        endBodyFat: Math.round(endVal * 10) / 10,
+        reductionRate,
+      };
+    })
+    .filter((r): r is RankingRow => r !== null)
+    .sort((a, b) => b.reductionRate - a.reductionRate)
+    .map((r, i) => ({ ...r, rank: i + 1 }));
+}
+
+export interface ChallengeData {
+  challenge: Challenge | null;
+  /** 챌린지 편집·순위 토글 후 클라이언트 상태를 즉시 반영하기 위한 세터. */
+  setChallenge: (c: Challenge) => void;
+  participants: ParticipantWithSubmissions[];
+  ranking: RankingRow[];
+  logsByParticipant: Record<string, import('../types').WeeklyLog[]>;
+  logsLoading: boolean;
+  loading: boolean;
+  /** 로딩 시작 후 경과 ms — 스켈레톤 지연 표시용. */
+  loadingElapsedMs: number;
+  /** 챌린지를 찾지 못했을 때의 메시지 (빈 문자열이면 정상). */
+  error: string;
+  refetchParticipants: () => Promise<void>;
+  refetchLogs: () => Promise<void>;
+}
+
+export function useChallengeData(code: string | undefined): ChallengeData {
+  const [challenge, setChallenge] = useState<Challenge | null>(null);
+  const [participants, setParticipants] = useState<ParticipantWithSubmissions[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadingElapsedMs, setLoadingElapsedMs] = useState(0);
+  const [error, setError] = useState('');
+
+  const fetchChallenge = useCallback(async () => {
+    if (!code) {
+      setLoading(false);
+      return;
+    }
+    // Sprint 3 Phase A: 공개 컬럼만 노출하는 challenges_public VIEW 사용.
+    const { data, error: err } = await supabase
+      .from('challenges_public')
+      .select('*')
+      .eq('code', code.toUpperCase())
+      .single();
+    if (err || !data) {
+      setError('대결을 찾을 수 없습니다.');
+      setChallenge(null);
+    } else {
+      setChallenge(data as Challenge);
+      setError('');
+    }
+    setLoading(false);
+  }, [code]);
+
+  const fetchParticipants = useCallback(async () => {
+    if (!challenge) return;
+    // Sprint 3 Phase B: submissions 를 임베드해 1회 호출로 페치 (기존 N+1 제거).
+    const { data } = await supabase
+      .from('participants')
+      .select('*, submissions(*)')
+      .eq('challenge_id', challenge.id)
+      .order('created_at');
+    setParticipants((data as ParticipantWithSubmissions[]) ?? []);
+  }, [challenge]);
+
+  useEffect(() => {
+    fetchChallenge();
+  }, [fetchChallenge]);
+
+  useEffect(() => {
+    fetchParticipants();
+  }, [fetchParticipants]);
+
+  // 로딩 경과 시간 — 스켈레톤을 너무 일찍/늦게 보여주지 않도록.
+  useEffect(() => {
+    if (!loading) {
+      setLoadingElapsedMs(0);
+      return;
+    }
+    const startedAt = performance.now();
+    const timer = window.setInterval(() => {
+      setLoadingElapsedMs(Math.round(performance.now() - startedAt));
+    }, 100);
+    return () => window.clearInterval(timer);
+  }, [loading]);
+
+  const participantIds = useMemo(() => participants.map((p) => p.id), [participants]);
+  const {
+    logsByParticipant,
+    loading: logsLoading,
+    refetch: refetchLogs,
+  } = useAllWeeklyLogsForChallenge(participantIds);
+
+  const ranking = useMemo(() => computeRanking(participants), [participants]);
+
+  return {
+    challenge,
+    setChallenge,
+    participants,
+    ranking,
+    logsByParticipant,
+    logsLoading,
+    loading,
+    loadingElapsedMs,
+    error,
+    refetchParticipants: fetchParticipants,
+    refetchLogs,
+  };
+}

--- a/burnfat/src/lib/__tests__/deviceSecret.test.ts
+++ b/burnfat/src/lib/__tests__/deviceSecret.test.ts
@@ -1,5 +1,12 @@
-import { describe, it, expect } from 'vitest';
-import { generateDeviceSecret, hashDeviceSecret } from '../deviceSecret';
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  generateDeviceSecret,
+  hashDeviceSecret,
+  saveDeviceSecret,
+  loadDeviceSecret,
+  clearDeviceSecret,
+  prepareDeviceSecret,
+} from '../deviceSecret';
 
 // Sprint 3 Phase A — Vitest 인프라 동작 확인용 샘플 1개.
 // jsdom 환경에서 Web Crypto(crypto.getRandomValues / crypto.subtle) 가
@@ -29,5 +36,42 @@ describe('deviceSecret', () => {
     const h1 = await hashDeviceSecret('secret-one');
     const h2 = await hashDeviceSecret('secret-two');
     expect(h1).not.toBe(h2);
+  });
+});
+
+// Sprint 3 Phase B 보강 — localStorage 영속 + INSERT 사이클.
+describe('deviceSecret — 영속화', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('save → load 라운드트립이 동일 값을 돌려준다', () => {
+    saveDeviceSecret('weekly_logs', 'row-1', 'plain-secret');
+    expect(loadDeviceSecret('weekly_logs', 'row-1')).toBe('plain-secret');
+  });
+
+  it('저장되지 않은 row 는 null', () => {
+    expect(loadDeviceSecret('submissions', 'unknown-row')).toBeNull();
+  });
+
+  it('table 별로 키가 분리된다', () => {
+    saveDeviceSecret('weekly_logs', 'row-1', 'wl-secret');
+    saveDeviceSecret('submissions', 'row-1', 'sub-secret');
+    expect(loadDeviceSecret('weekly_logs', 'row-1')).toBe('wl-secret');
+    expect(loadDeviceSecret('submissions', 'row-1')).toBe('sub-secret');
+  });
+
+  it('clear 후에는 load 가 null 을 반환한다', () => {
+    saveDeviceSecret('submissions', 'row-1', 'plain');
+    clearDeviceSecret('submissions', 'row-1');
+    expect(loadDeviceSecret('submissions', 'row-1')).toBeNull();
+  });
+
+  it('prepareDeviceSecret 는 plain·hash 쌍을 만들고 persist 가 저장한다', async () => {
+    const { plain, hash, persist } = await prepareDeviceSecret('weekly_logs');
+    expect(plain).toMatch(/^[0-9a-f]{64}$/);
+    expect(hash).toBe(await hashDeviceSecret(plain));
+    persist('row-9');
+    expect(loadDeviceSecret('weekly_logs', 'row-9')).toBe(plain);
   });
 });

--- a/burnfat/src/lib/__tests__/signedImage.test.ts
+++ b/burnfat/src/lib/__tests__/signedImage.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// signedImage 가 supabase 클라이언트를 import 하므로 (extractStoragePath/
+// isStoragePath 는 쓰지 않지만) 모듈 로드를 위해 mock 으로 대체한다.
+vi.mock('../supabase', () => ({
+  supabase: { storage: { from: vi.fn() } },
+}));
+
+import { extractStoragePath, isStoragePath } from '../signedImage';
+
+describe('extractStoragePath', () => {
+  it('이미 path 형태면 그대로 반환한다', () => {
+    expect(extractStoragePath('participant-1/start-1234.jpg')).toBe(
+      'participant-1/start-1234.jpg'
+    );
+  });
+
+  it('선행 슬래시는 제거한다', () => {
+    expect(extractStoragePath('/participant-1/start.jpg')).toBe(
+      'participant-1/start.jpg'
+    );
+  });
+
+  it('Supabase public URL 에서 bucket 내부 path 를 추출한다', () => {
+    const url =
+      'https://abc.supabase.co/storage/v1/object/public/inbody/p1/start-9.jpg';
+    expect(extractStoragePath(url)).toBe('p1/start-9.jpg');
+  });
+
+  it('Supabase sign URL(토큰 포함) 에서 path 를 추출한다', () => {
+    const url =
+      'https://abc.supabase.co/storage/v1/object/sign/inbody/p1/end-9.jpg?token=xyz';
+    expect(extractStoragePath(url)).toBe('p1/end-9.jpg');
+  });
+
+  it('inbody 버킷이 아닌 외부 URL 은 null 을 반환한다', () => {
+    expect(extractStoragePath('https://example.com/photo.jpg')).toBeNull();
+  });
+
+  it('null / 빈 문자열은 null', () => {
+    expect(extractStoragePath(null)).toBeNull();
+    expect(extractStoragePath('')).toBeNull();
+    expect(extractStoragePath('   ')).toBeNull();
+  });
+});
+
+describe('isStoragePath', () => {
+  it('http 로 시작하지 않으면 path 로 본다', () => {
+    expect(isStoragePath('p1/start.jpg')).toBe(true);
+  });
+
+  it('http(s) URL 은 path 가 아니다', () => {
+    expect(isStoragePath('https://abc.supabase.co/x.jpg')).toBe(false);
+  });
+
+  it('빈 값은 false', () => {
+    expect(isStoragePath(null)).toBe(false);
+  });
+});

--- a/burnfat/src/pages/ChallengePage.tsx
+++ b/burnfat/src/pages/ChallengePage.tsx
@@ -1,436 +1,117 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
-import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
-import Card from '@mui/material/Card';
-import CardContent from '@mui/material/CardContent';
-import Tabs from '@mui/material/Tabs';
-import Tab from '@mui/material/Tab';
-import Table from '@mui/material/Table';
-import TableBody from '@mui/material/TableBody';
-import TableCell from '@mui/material/TableCell';
-import TableContainer from '@mui/material/TableContainer';
-import TableHead from '@mui/material/TableHead';
-import TableRow from '@mui/material/TableRow';
-import Paper from '@mui/material/Paper';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { useTheme } from '@mui/material/styles';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
-import AddIcon from '@mui/icons-material/Add';
-import EditIcon from '@mui/icons-material/Edit';
-import ContentCopyIcon from '@mui/icons-material/ContentCopy';
-import PhotoCameraIcon from '@mui/icons-material/PhotoCamera';
-import ShareIcon from '@mui/icons-material/Share';
-import LockOpenIcon from '@mui/icons-material/LockOpen';
-import LockIcon from '@mui/icons-material/Lock';
-import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
-import IconButton from '@mui/material/IconButton';
-import Tooltip from '@mui/material/Tooltip';
-import Snackbar from '@mui/material/Snackbar';
-import Dialog from '@mui/material/Dialog';
-import DialogTitle from '@mui/material/DialogTitle';
-import DialogContent from '@mui/material/DialogContent';
-import DialogActions from '@mui/material/DialogActions';
-import InputAdornment from '@mui/material/InputAdornment';
 import { supabase } from '../lib/supabase';
-import type { Challenge, ParticipantWithSubmissions, RankingRow } from '../types';
-import SubmitModal from '../components/SubmitModal';
-import ParticipantBasicInfoDialog from '../components/ParticipantBasicInfoDialog';
-import WeeklyLogForm from '../components/WeeklyLogForm';
-import AllParticipantsChart from '../components/AllParticipantsChart';
-import RecordStatusSummary from '../components/RecordStatusSummary';
-import ParticipantWeeklyLogCard from '../components/ParticipantWeeklyLogCard';
-import ChallengePageSkeleton from '../components/ChallengePageSkeleton';
-import WeeklyLogsUpgradeNoticeDialog, {
-  dismissWeeklyLogsUpgradeNotice,
-  shouldShowWeeklyLogsUpgradeNotice,
-} from '../components/WeeklyLogsUpgradeNoticeDialog';
-import { useAllWeeklyLogsForChallenge } from '../hooks/useWeeklyLogs';
-import { useRecordStatus } from '../hooks/useRecordStatus';
+import type { ParticipantWithSubmissions } from '../types';
+import { useChallengeData } from '../hooks/useChallengeData';
 import { useParticipantIdentity } from '../hooks/useParticipantIdentity';
+import { useRecordStatus } from '../hooks/useRecordStatus';
 import { useNextRecordableWeek } from '../hooks/useNextRecordableWeek';
-import { resolveImageUrl } from '../lib/signedImage';
 import { getDDayDisplay } from '../lib/challengeSchedule';
 import { hasSeenNotice, markNoticeSeen } from '../lib/oneTimeNotice';
-import MyStatusCard from '../components/MyStatusCard';
-import DDayChip from '../components/DDayChip';
-import EndingSoonDialog, {
+import ChallengeHeader from '../components/ChallengeHeader';
+import ChallengeTabs from '../components/ChallengeTabs';
+import ParticipantsTabHeader from '../components/ParticipantsTabHeader';
+import ParticipantsTab from '../components/ParticipantsTab';
+import RankingTab from '../components/RankingTab';
+import WeeklyLogsTab from '../components/WeeklyLogsTab';
+import ChallengeOverlays, { type SubmitTarget } from '../components/ChallengeOverlays';
+import type { AdminPinAction } from '../components/AdminPinDialog';
+import ChallengePageSkeleton from '../components/ChallengePageSkeleton';
+import {
   shouldShowEndingSoonNotice,
   dismissEndingSoonNotice,
 } from '../components/EndingSoonDialog';
-import RankingShareDialog from '../components/RankingShareDialog';
-import GoalProgressWidget from '../components/GoalProgressWidget';
+import {
+  dismissWeeklyLogsUpgradeNotice,
+  shouldShowWeeklyLogsUpgradeNotice,
+} from '../components/WeeklyLogsUpgradeNoticeDialog';
 
-// Sprint 0.4: 디버그 플래그를 빌드 시점 환경 변수로 분리.
-//   - VITE_DEBUG_SHOW_RANKING="true"           → 순위 항상 공개 (개발 전용)
-//   - VITE_DEBUG_ALLOW_EARLY_END_SUBMIT="true" → 종료일 전 종료 인증 허용
-// 운영 빌드에서는 변수를 비워두거나 "false" 로 설정하세요.
-const DEBUG_SHOW_RANKING =
-  (import.meta.env.VITE_DEBUG_SHOW_RANKING ?? '').toLowerCase() === 'true';
+// Sprint 0.4: 디버그 플래그 — 운영 빌드에서는 미설정/"false".
 const DEBUG_ALLOW_EARLY_END_SUBMIT =
   (import.meta.env.VITE_DEBUG_ALLOW_EARLY_END_SUBMIT ?? '').toLowerCase() === 'true';
 
-const END_BTN_COLORS = [
-  { main: '#16a34a', glow: 'rgba(22, 163, 74, 0.5)' },
-  { main: '#2563eb', glow: 'rgba(37, 99, 235, 0.5)' },
-  { main: '#7c3aed', glow: 'rgba(124, 58, 237, 0.5)' },
-  { main: '#db2777', glow: 'rgba(219, 39, 119, 0.5)' },
-  { main: '#ea580c', glow: 'rgba(234, 88, 12, 0.5)' },
-  { main: '#0891b2', glow: 'rgba(8, 145, 178, 0.5)' },
-  { main: '#059669', glow: 'rgba(5, 150, 105, 0.5)' },
-  { main: '#ca8a04', glow: 'rgba(202, 138, 4, 0.5)' },
-];
-const getEndBtnColor = (participantId: string) => {
-  let hash = 0;
-  for (let i = 0; i < participantId.length; i++) hash = (hash << 5) - hash + participantId.charCodeAt(i);
-  return END_BTN_COLORS[Math.abs(hash) % END_BTN_COLORS.length];
-};
-
+/**
+ * Sprint 3 Phase B — ChallengePage 는 데이터 페치(useChallengeData)와
+ * 탭/오버레이 조율만 담당한다. 화면은 ChallengeHeader / 3개 탭 / ChallengeOverlays 가 맡는다.
+ */
 export default function ChallengePage() {
   const { code } = useParams<{ code: string }>();
   const navigate = useNavigate();
   const theme = useTheme();
   const prefersReducedMotion = useMediaQuery('(prefers-reduced-motion: reduce)');
-  const [challenge, setChallenge] = useState<Challenge | null>(null);
-  const [participants, setParticipants] = useState<ParticipantWithSubmissions[]>([]);
-  const [ranking, setRanking] = useState<RankingRow[]>([]);
+
+  const {
+    challenge,
+    setChallenge,
+    participants,
+    ranking,
+    logsByParticipant,
+    logsLoading,
+    loading,
+    loadingElapsedMs,
+    error,
+    refetchParticipants,
+    refetchLogs,
+  } = useChallengeData(code);
+
+  const { myParticipant, remember, forget } = useParticipantIdentity(
+    challenge?.id,
+    participants
+  );
+  const recordStatus = useRecordStatus(
+    participants,
+    logsByParticipant,
+    challenge?.start_date || ''
+  );
+  const myLogs = myParticipant ? logsByParticipant[myParticipant.id] || [] : [];
+  const myWeekly = useNextRecordableWeek(
+    myLogs,
+    challenge?.start_date || '',
+    challenge?.end_date || ''
+  );
+
   const [tab, setTab] = useState(0);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState('');
-  const [joinNickname, setJoinNickname] = useState('');
-  const [joinLoading, setJoinLoading] = useState(false);
-  const [basicInfoDialog, setBasicInfoDialog] = useState<ParticipantWithSubmissions | null>(null);
-  const [basicInfoDialogAfterJoin, setBasicInfoDialogAfterJoin] = useState(false);
-  // Sprint 1.5: 폼 진입 시 기본 주차를 함께 전달 (미입력 주차 placeholder 클릭 시 그 주차로 직행).
-  const [weeklyLogTarget, setWeeklyLogTarget] = useState<
-    { participant: ParticipantWithSubmissions; defaultWeekNo?: number } | null
-  >(null);
-  const [submitModal, setSubmitModal] = useState<{
-    open: boolean;
-    participantId: string;
-    participantNickname: string;
-    type: 'start' | 'end';
-  } | null>(null);
-  const [snackbar, setSnackbar] = useState(false);
-  const [earlyEndBlockSnackbar, setEarlyEndBlockSnackbar] = useState(false);
-  const [toast, setToast] = useState<string | null>(null);
-  const [pinDialog, setPinDialog] = useState(false);
-  const [pinInput, setPinInput] = useState('');
-  const [pinError, setPinError] = useState('');
-  const [pinLoading, setPinLoading] = useState(false);
-  const [weeklyLogsNoticeOpen, setWeeklyLogsNoticeOpen] = useState(false);
-  const [pendingPinAction, setPendingPinAction] = useState<'ranking' | 'editChallenge'>('ranking');
   const prevTabRef = useRef(0);
-  // 챌린지 기본정보 수정
-  const [challengeEditOpen, setChallengeEditOpen] = useState(false);
-  const [editTitle, setEditTitle] = useState('');
-  const [editStartDate, setEditStartDate] = useState('');
-  const [editEndDate, setEditEndDate] = useState('');
-  const [editStakeAmount, setEditStakeAmount] = useState(0);
-  const [editLoading, setEditLoading] = useState(false);
-  const [editError, setEditError] = useState('');
-  const [loadingElapsedMs, setLoadingElapsedMs] = useState(0);
-  // Sprint 1: 개인 상태 카드 / 종료 임박 모달 / 랭킹 공유
-  const [showJoinForm, setShowJoinForm] = useState(false);
+  const [submitTarget, setSubmitTarget] = useState<SubmitTarget | null>(null);
+  const [basicInfo, setBasicInfo] = useState<{
+    participant: ParticipantWithSubmissions;
+    afterJoin: boolean;
+  } | null>(null);
+  const [weeklyLogTarget, setWeeklyLogTarget] = useState<{
+    participant: ParticipantWithSubmissions;
+    defaultWeekNo?: number;
+  } | null>(null);
+  const [copySnackbar, setCopySnackbar] = useState(false);
+  const [earlyEndSnackbar, setEarlyEndSnackbar] = useState(false);
+  const [toast, setToast] = useState<string | null>(null);
+  const [pinAction, setPinAction] = useState<AdminPinAction | null>(null);
+  const [editOpen, setEditOpen] = useState(false);
   const [endingSoonOpen, setEndingSoonOpen] = useState(false);
-  const [rankingShareOpen, setRankingShareOpen] = useState(false);
+  const [weeklyLogsNoticeOpen, setWeeklyLogsNoticeOpen] = useState(false);
 
-  const fetchChallenge = useCallback(async () => {
-    if (!code) {
-      setLoading(false);
-      return;
-    }
-    // Sprint 3 Phase A: 공개 컬럼만 노출하는 challenges_public VIEW 사용.
-    // VIEW 는 admin_pin_hash 를 포함하지 않으므로 `.select('*')` 가 안전하다
-    // (Sprint 0 의 컬럼 레벨 GRANT 회귀를 구조적으로 차단). 마이그레이션
-    // 20260601000001_challenges_public_view.sql 참고.
-    const { data, error: err } = await supabase
-      .from('challenges_public')
-      .select('*')
-      .eq('code', code.toUpperCase())
-      .single();
-    if (err || !data) {
-      setError('대결을 찾을 수 없습니다.');
-      setChallenge(null);
-    } else {
-      setChallenge(data as Challenge);
-      setError('');
-    }
-    setLoading(false);
-  }, [code]);
-
-  const fetchParticipants = useCallback(async () => {
-    if (!challenge) return;
-    const { data: parts } = await supabase.from('participants').select('*').eq('challenge_id', challenge.id).order('created_at');
-    if (!parts?.length) {
-      setParticipants([]);
-      setRanking([]);
-      return;
-    }
-
-    const withSubs: ParticipantWithSubmissions[] = await Promise.all(
-      parts.map(async (p) => {
-        const { data: subs } = await supabase.from('submissions').select('*').eq('participant_id', p.id);
-        return { ...p, submissions: subs || [] } as ParticipantWithSubmissions;
-      })
-    );
-    setParticipants(withSubs);
-
-    const rows: RankingRow[] = withSubs
-      .map((p) => {
-        const start = p.submissions.find((s) => s.type === 'start');
-        const end = p.submissions.find((s) => s.type === 'end');
-        if (!start || !end) return null;
-        const startVal = Number(start.body_fat_rate);
-        const endVal = Number(end.body_fat_rate);
-        // (시작 - 종료) / 시작 × 100 → 시작 체지방 대비 상대 감소율
-        const reductionRate = startVal > 0
-          ? Math.round(((startVal - endVal) / startVal) * 10000) / 100
-          : 0;
-        return {
-          rank: 0,
-          nickname: p.nickname,
-          startBodyFat: Math.round(startVal * 10) / 10,
-          endBodyFat: Math.round(endVal * 10) / 10,
-          reductionRate,
-        };
-      })
-      .filter((r): r is RankingRow => r !== null)
-      .sort((a, b) => b.reductionRate - a.reductionRate)
-      .map((r, i) => ({ ...r, rank: i + 1 }));
-    setRanking(rows);
-  }, [challenge]);
-
+  // 주간 기록 탭 첫 진입 시 업그레이드 안내 1회.
   useEffect(() => {
-    fetchChallenge();
-  }, [fetchChallenge]);
-
-  useEffect(() => {
-    if (!loading) {
-      setLoadingElapsedMs(0);
-      return;
-    }
-
-    const startedAt = performance.now();
-    const timer = window.setInterval(() => {
-      setLoadingElapsedMs(Math.round(performance.now() - startedAt));
-    }, 100);
-
-    return () => {
-      window.clearInterval(timer);
-    };
-  }, [loading]);
-
-  useEffect(() => {
-    fetchParticipants();
-  }, [fetchParticipants]);
-
-  useEffect(() => {
-    const prevTab = prevTabRef.current;
-    const enteredWeeklyLogsTab = tab === 2 && prevTab !== 2;
-    if (enteredWeeklyLogsTab && shouldShowWeeklyLogsUpgradeNotice()) {
+    const prev = prevTabRef.current;
+    if (tab === 2 && prev !== 2 && shouldShowWeeklyLogsUpgradeNotice()) {
       setWeeklyLogsNoticeOpen(true);
     }
     prevTabRef.current = tab;
   }, [tab]);
 
-  const shareUrl = challenge ? `${window.location.origin}/c/${challenge.code}` : '';
-  const handleCopyShare = () => {
-    navigator.clipboard.writeText(shareUrl).then(() => setSnackbar(true));
-  };
-
-  const handleCloseWeeklyLogsNotice = () => {
-    dismissWeeklyLogsUpgradeNotice();
-    setWeeklyLogsNoticeOpen(false);
-  };
-
-  // Sprint 1: 결과 공유는 RankingShareDialog (PNG 이미지 + 텍스트) 로 일원화.
-  const handleOpenRankingShare = () => {
-    if (!challenge || ranking.length === 0) return;
-    setRankingShareOpen(true);
-  };
-
-  const openPinDialog = (action: 'ranking' | 'editChallenge') => {
-    setPinInput('');
-    setPinError('');
-    setPinLoading(false);
-    setPendingPinAction(action);
-    setPinDialog(true);
-  };
-
-  const handleUnlockRanking = () => {
-    if (!challenge) return;
-    if (challenge.has_admin_pin) {
-      openPinDialog('ranking');
-    } else {
-      doToggleRanking();
-    }
-  };
-
-  const handleEditChallengeOpen = () => {
-    if (!challenge) return;
-    if (challenge.has_admin_pin) {
-      openPinDialog('editChallenge');
-    } else {
-      openChallengeEditDialog();
-    }
-  };
-
-  const openChallengeEditDialog = () => {
-    if (!challenge) return;
-    setEditTitle(challenge.title);
-    setEditStartDate(challenge.start_date);
-    setEditEndDate(challenge.end_date);
-    setEditStakeAmount(challenge.stake_amount);
-    setEditError('');
-    setChallengeEditOpen(true);
-  };
-
-  const handleChallengeEditSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!challenge) return;
-    if (!editTitle.trim()) { setEditError('대결 이름을 입력하세요.'); return; }
-    if (!editStartDate || !editEndDate) { setEditError('기간을 입력하세요.'); return; }
-    if (editStartDate >= editEndDate) { setEditError('종료일은 시작일 이후여야 합니다.'); return; }
-    setEditLoading(true);
-    setEditError('');
-    const { error: err } = await supabase
-      .from('challenges')
-      .update({
-        title: editTitle.trim(),
-        start_date: editStartDate,
-        end_date: editEndDate,
-        stake_amount: editStakeAmount,
-      })
-      .eq('id', challenge.id);
-    setEditLoading(false);
-    if (err) { setEditError(err.message); return; }
-    setChallenge({ ...challenge, title: editTitle.trim(), start_date: editStartDate, end_date: editEndDate, stake_amount: editStakeAmount });
-    setChallengeEditOpen(false);
-    setToast('챌린지 정보가 수정되었습니다');
-  };
-
-  const normalizeAdminPin = (p: string | null | undefined) => String(p ?? '').trim().replace(/\D/g, '');
-
-  // Sprint 0.1: 클라이언트 비교가 아닌 서버 RPC 로 PIN 검증
-  const verifyAdminPinOnServer = async (pin: string): Promise<boolean> => {
-    if (!challenge) return false;
-    const cleaned = normalizeAdminPin(pin);
-    if (cleaned.length !== 4) return false;
-    const { data, error } = await supabase.rpc('verify_admin_pin', {
-      p_challenge_id: challenge.id,
-      p_pin: cleaned,
-    });
-    if (error) {
-      // 네트워크/RPC 오류는 거부 처리. 사용자에게는 일반 메시지로 안내.
-      return false;
-    }
-    return data === true;
-  };
-
-  const doToggleRanking = async (): Promise<boolean> => {
-    if (!challenge) return false;
-    const next = !(challenge.ranking_unlocked ?? false);
-    try {
-      const { error } = await supabase
-        .from('challenges')
-        .update({ ranking_unlocked: next })
-        .eq('id', challenge.id);
-      if (error) {
-        setToast(`설정 실패: ${error.message}`);
-        return false;
-      }
-      setChallenge({ ...challenge, ranking_unlocked: next });
-      setToast(next ? '중간 순위가 공개되었습니다' : '순위가 다시 잠겼습니다');
-      return true;
-    } catch {
-      setToast('순위 공개 설정 중 오류가 발생했습니다');
-      return false;
-    }
-  };
-
-  const handlePinSubmit = async () => {
-    if (!challenge) return;
-    const got = normalizeAdminPin(pinInput);
-    if (got.length !== 4) {
-      setPinError('PIN은 숫자 4자리입니다.');
-      return;
-    }
-    setPinLoading(true);
-    setPinError('');
-    const ok = await verifyAdminPinOnServer(got);
-    if (!ok) {
-      setPinLoading(false);
-      setPinError('PIN이 올바르지 않습니다.');
-      return;
-    }
-    if (pendingPinAction === 'ranking') {
-      const toggleOk = await doToggleRanking();
-      setPinLoading(false);
-      if (toggleOk) {
-        setPinInput('');
-        setPinDialog(false);
-      }
-    } else if (pendingPinAction === 'editChallenge') {
-      setPinLoading(false);
-      setPinInput('');
-      setPinDialog(false);
-      openChallengeEditDialog();
-    }
-  };
-
-  const handleJoin = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!challenge || !joinNickname.trim()) return;
-    setJoinLoading(true);
-    const { data: newParticipant, error: err } = await supabase
-      .from('participants')
-      .insert({ challenge_id: challenge.id, nickname: joinNickname.trim() })
-      .select()
-      .single();
-    setJoinLoading(false);
-    if (err) {
-      setError(err.message.includes('unique') ? '이미 등록된 닉네임입니다.' : err.message);
-      return;
-    }
-    setError('');
-    setJoinNickname('');
-    fetchParticipants();
-    // Sprint 1: 방금 등록한 참가자를 이 디바이스의 "나" 로 기억 → 재방문 시 개인 상태 카드.
-    rememberMe((newParticipant as ParticipantWithSubmissions).id);
-    setShowJoinForm(false);
-    setBasicInfoDialog({ ...(newParticipant as ParticipantWithSubmissions), submissions: [] });
-    setBasicInfoDialogAfterJoin(true);
-  };
-
-  const participantIds = participants.map((p) => p.id);
-  const { logsByParticipant, loading: logsLoading, refetch: refetchLogs } =
-    useAllWeeklyLogsForChallenge(participantIds);
-  const recordStatus = useRecordStatus(participants, logsByParticipant, challenge?.start_date || '');
-
-  // Sprint 1: 내 참가자 식별 + 내 주간 기록 상태
-  const { myParticipant, remember: rememberMe, forget: forgetMe } = useParticipantIdentity(
-    challenge?.id,
-    participants
-  );
-  const myWeekly = useNextRecordableWeek(
-    myParticipant ? logsByParticipant[myParticipant.id] || [] : [],
-    challenge?.start_date || '',
-    challenge?.end_date || ''
-  );
-
-  // Sprint 1: 종료 임박 모달 — 종료 24h 이내 진입 시 챌린지당 1회
+  // Sprint 1: 종료 임박 모달 — 종료 24h 이내 진입 시 챌린지당 1회.
   useEffect(() => {
     if (!challenge) return;
     const dd = getDDayDisplay(challenge.start_date, challenge.end_date);
-    if (dd.endingSoon && shouldShowEndingSoonNotice(challenge.id)) {
-      setEndingSoonOpen(true);
-    }
+    if (dd.endingSoon && shouldShowEndingSoonNotice(challenge.id)) setEndingSoonOpen(true);
   }, [challenge]);
 
-  // Sprint 1: 백필 권고 토스트 — 내 미입력 주차가 2개 이상이면 챌린지당 1회
+  // Sprint 1: 백필 권고 토스트 — 내 미입력 주차가 2개 이상이면 챌린지당 1회.
   useEffect(() => {
     if (!challenge || !myParticipant || logsLoading) return;
     if (myWeekly.missingWeeks.length < 2) return;
@@ -445,16 +126,9 @@ export default function ChallengePage() {
   if (loading) {
     if (loadingElapsedMs < 300) {
       return (
-        <Box
-          sx={{
-            minHeight: '50vh',
-            bgcolor: theme.palette.background.default,
-          }}
-          aria-hidden
-        />
+        <Box sx={{ minHeight: '50vh', bgcolor: theme.palette.background.default }} aria-hidden />
       );
     }
-
     return (
       <Box sx={{ minHeight: '100vh', bgcolor: 'background.default' }}>
         <ChallengePageSkeleton disableAnimation={prefersReducedMotion} />
@@ -478,7 +152,9 @@ export default function ChallengePage() {
         <Button startIcon={<ArrowBackIcon />} onClick={() => navigate('/')}>
           홈
         </Button>
-        <Typography color="error" sx={{ mt: 2 }}>{error}</Typography>
+        <Typography color="error" sx={{ mt: 2 }}>
+          {error}
+        </Typography>
       </Box>
     );
   }
@@ -487,46 +163,64 @@ export default function ChallengePage() {
   const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
   const endDateOnly = (challenge.end_date || '').split('T')[0].slice(0, 10);
   const isBeforeStartDate = challenge.start_date > today;
-  // end_date가 없으면 안전하게 차단(모달 열지 않음). 빈 문자열일 때 '' > today 는 false가 되어 잘못 모달이 열리는 버그 방지
+  // end_date가 없으면 안전하게 차단(모달 열지 않음).
   const isBeforeEndDate = !endDateOnly ? true : endDateOnly > today;
-
-  // Sprint 1: D-Day 표시 모델 (헤더 칩 + 종료 임박 모달이 공유)
   const dday = getDDayDisplay(challenge.start_date, challenge.end_date);
+  const shareUrl = `${window.location.origin}/c/${challenge.code}`;
+  const allEndComplete = (() => {
+    const withStart = participants.filter((p) => p.submissions.some((s) => s.type === 'start'));
+    return (
+      withStart.length > 0 && withStart.every((p) => p.submissions.some((s) => s.type === 'end'))
+    );
+  })();
 
-  // Sprint 1: 시작/종료 인증 모달 진입 — 개인 상태 카드와 참가자 카드가 공유.
   const openStartAuth = (p: ParticipantWithSubmissions) => {
     if (isBeforeStartDate) {
       setToast(`시작일(${challenge.start_date}) 이후에 인증을 권장하지만, 미리 제출도 가능합니다.`);
     }
-    setSubmitModal({ open: true, participantId: p.id, participantNickname: p.nickname, type: 'start' });
+    setSubmitTarget({ participantId: p.id, participantNickname: p.nickname, type: 'start' });
   };
   const openEndAuth = (p: ParticipantWithSubmissions) => {
-    if (isBeforeEndDate && !DEBUG_ALLOW_EARLY_END_SUBMIT) {
-      setEarlyEndBlockSnackbar(true);
-    } else {
-      setSubmitModal({ open: true, participantId: p.id, participantNickname: p.nickname, type: 'end' });
+    if (isBeforeEndDate && !DEBUG_ALLOW_EARLY_END_SUBMIT) setEarlyEndSnackbar(true);
+    else setSubmitTarget({ participantId: p.id, participantNickname: p.nickname, type: 'end' });
+  };
+
+  const doToggleRanking = async (): Promise<boolean> => {
+    const next = !(challenge.ranking_unlocked ?? false);
+    try {
+      const { error: err } = await supabase
+        .from('challenges')
+        .update({ ranking_unlocked: next })
+        .eq('id', challenge.id);
+      if (err) {
+        setToast(`설정 실패: ${err.message}`);
+        return false;
+      }
+      setChallenge({ ...challenge, ranking_unlocked: next });
+      setToast(next ? '중간 순위가 공개되었습니다' : '순위가 다시 잠겼습니다');
+      return true;
+    } catch {
+      setToast('순위 공개 설정 중 오류가 발생했습니다');
+      return false;
     }
   };
 
-  const participantsWithStart = participants.filter((p) => p.submissions.some((s) => s.type === 'start'));
-  const allEndComplete = participantsWithStart.length > 0 && participantsWithStart.every((p) =>
-    p.submissions.some((s) => s.type === 'end')
-  );
-  const showRanking = allEndComplete || (challenge?.ranking_unlocked ?? false) || DEBUG_SHOW_RANKING;
+  const handleUnlockRanking = () => {
+    if (challenge.has_admin_pin) setPinAction('ranking');
+    else void doToggleRanking();
+  };
+  const handleEditChallengeOpen = () => {
+    if (challenge.has_admin_pin) setPinAction('editChallenge');
+    else setEditOpen(true);
+  };
+  const handlePinConfirmed = async (): Promise<boolean> => {
+    if (pinAction === 'ranking') return doToggleRanking();
+    setEditOpen(true);
+    return true;
+  };
 
-  const participantsWithRank = [...participants]
-    .map((p) => {
-      const start = p.submissions.find((s) => s.type === 'start');
-      const startBodyFat = start ? Number(start.body_fat_rate) : null;
-      return { ...p, startBodyFat };
-    })
-    .sort((a, b) => {
-      if (a.startBodyFat == null && b.startBodyFat == null) return 0;
-      if (a.startBodyFat == null) return 1;
-      if (b.startBodyFat == null) return -1;
-      return b.startBodyFat - a.startBodyFat;
-    });
-  const topStartBodyFat = participantsWithRank.find((p) => p.startBodyFat != null)?.startBodyFat ?? null;
+  const openWeeklyLog = (p: ParticipantWithSubmissions, weekNo?: number) =>
+    setWeeklyLogTarget({ participant: p, defaultWeekNo: weekNo });
 
   return (
     <Box sx={{ minHeight: '100vh', bgcolor: 'background.default', pb: 4 }}>
@@ -536,727 +230,116 @@ export default function ChallengePage() {
         </Button>
       </Box>
 
-      <Box sx={{ px: 2, pb: 2 }}>
-        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 1 }}>
-          <Box>
-            <Typography variant="h5" fontWeight={700} gutterBottom>
-              {challenge.title}
-            </Typography>
-            <Typography variant="body2" color="text.secondary">
-              {challenge.start_date} ~ {challenge.end_date} · 참가비 {challenge.stake_amount.toLocaleString()}원
-            </Typography>
-            <Typography variant="body2" color="text.secondary">
-              대결 코드: <strong>{challenge.code}</strong>
-            </Typography>
-          </Box>
-          <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 0.5 }}>
-            <DDayChip dday={dday} />
-            <Box sx={{ display: 'flex', gap: 0.5 }}>
-              <Tooltip title="챌린지 정보 수정">
-                <IconButton
-                  onClick={handleEditChallengeOpen}
-                  size="small"
-                  color="default"
-                  aria-label="챌린지 정보 수정"
-                >
-                  <EditIcon />
-                </IconButton>
-              </Tooltip>
-              <Tooltip title="URL 복사">
-                <IconButton
-                  onClick={handleCopyShare}
-                  color="primary"
-                  size="small"
-                  aria-label="대결 URL 복사"
-                >
-                  <ContentCopyIcon />
-                </IconButton>
-              </Tooltip>
-            </Box>
-          </Box>
-        </Box>
-      </Box>
+      <ChallengeHeader
+        challenge={challenge}
+        dday={dday}
+        onEditClick={handleEditChallengeOpen}
+        onCopyShare={() =>
+          navigator.clipboard.writeText(shareUrl).then(() => setCopySnackbar(true))
+        }
+      />
 
       {tab === 0 && (
-        myParticipant && !showJoinForm ? (
-          <>
-            <MyStatusCard
-              participant={myParticipant}
-              logs={logsByParticipant[myParticipant.id] || []}
-              challengeStartDate={challenge.start_date}
-              challengeEndDate={challenge.end_date}
-              onAuthStart={() => openStartAuth(myParticipant)}
-              onAuthEnd={() => openEndAuth(myParticipant)}
-              onOpenWeeklyLog={(weekNo) => {
-                setTab(2);
-                setWeeklyLogTarget({ participant: myParticipant, defaultWeekNo: weekNo });
-              }}
-              onForget={forgetMe}
-            />
-            <Box sx={{ px: 2, mb: 1, textAlign: 'center' }}>
-              <Button size="small" variant="text" onClick={() => setShowJoinForm(true)}>
-                + 다른 참가자 추가
-              </Button>
-            </Box>
-          </>
-        ) : (
-          <Card sx={{ mx: 2, mb: 2 }}>
-            <CardContent sx={{ p: 2 }}>
-              <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 0.5 }}>
-                <Typography variant="subtitle2" color="text.secondary">
-                  참가하기
-                </Typography>
-                {myParticipant && (
-                  <Button size="small" variant="text" color="inherit" onClick={() => setShowJoinForm(false)}>
-                    취소
-                  </Button>
-                )}
-              </Box>
-              <form onSubmit={handleJoin} style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
-                <TextField
-                  size="small"
-                  placeholder="닉네임"
-                  value={joinNickname}
-                  onChange={(e) => setJoinNickname(e.target.value)}
-                  sx={{ flex: 1, minWidth: 0, '& .MuiInputBase-root': { minHeight: 40 } }}
-                />
-                <Button type="submit" variant="contained" size="small" disabled={joinLoading || !joinNickname.trim()} sx={{ minWidth: 80, minHeight: 40 }}>
-                  참가
-                </Button>
-              </form>
-              {error && (
-                <Typography color="error" variant="caption" sx={{ mt: 1, display: 'block' }}>
-                  {error}
-                </Typography>
-              )}
-            </CardContent>
-          </Card>
-        )
+        <ParticipantsTabHeader
+          challenge={challenge}
+          myParticipant={myParticipant}
+          myLogs={myLogs}
+          onAuthStart={openStartAuth}
+          onAuthEnd={openEndAuth}
+          onOpenWeeklyLog={(p, weekNo) => {
+            setTab(2);
+            openWeeklyLog(p, weekNo);
+          }}
+          onForget={forget}
+          onRemember={remember}
+          onJoined={(p) => setBasicInfo({ participant: p, afterJoin: true })}
+          onRefetch={refetchParticipants}
+        />
       )}
 
-      <Tabs
-        value={tab}
-        onChange={(_, v) => setTab(v)}
-        sx={{
-          px: 2,
-          position: 'sticky',
-          top: 0,
-          zIndex: 10,
-          bgcolor: 'background.default',
-          borderBottom: 1,
-          borderColor: 'divider',
-          '& .MuiTab-root': { minHeight: 48 },
-          '& .MuiTabs-flexContainer': { gap: 0 },
-        }}
-        variant="scrollable"
-        scrollButtons="auto"
-        allowScrollButtonsMobile
-      >
-        <Tab label="참가자 / 인증" />
-        <Tab label="순위" />
-        <Tab label="주간 기록" />
-      </Tabs>
+      <ChallengeTabs value={tab} onChange={setTab} />
 
       {tab === 0 && (
-        <Box sx={{ px: 2, pt: 2 }}>
-          {participantsWithRank.map((p, idx) => {
-            const gap = topStartBodyFat != null && p.startBodyFat != null ? topStartBodyFat - p.startBodyFat : null;
-            return (
-              <Card key={p.id} sx={{ mb: 2 }}>
-                <CardContent sx={{ p: 2 }}>
-                  <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap', gap: 1 }}>
-                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                      <Typography variant="body2" color="text.secondary" sx={{ minWidth: 24 }}>
-                        {p.startBodyFat != null ? `#${idx + 1}` : '-'}
-                      </Typography>
-                      <Typography fontWeight={600}>{p.nickname}</Typography>
-                      {gap != null && gap > 0 && (
-                        <Typography
-                          variant="caption"
-                          sx={{
-                            color: 'warning.main',
-                            fontWeight: 600,
-                            bgcolor: 'warning.50',
-                            px: 1,
-                            py: 0.25,
-                            borderRadius: 1,
-                          }}
-                        >
-                          1등과 격차 +{gap.toFixed(1)}%p
-                        </Typography>
-                      )}
-                    </Box>
-                    <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
-                      <Tooltip title="기본정보 수정">
-                        <IconButton
-                          size="small"
-                          onClick={() => { setBasicInfoDialog(p); setBasicInfoDialogAfterJoin(false); }}
-                          sx={{ p: 0.5, minWidth: 44, minHeight: 44 }}
-                          aria-label={`${p.nickname} 기본정보 수정`}
-                        >
-                          <EditIcon sx={{ fontSize: 18 }} />
-                        </IconButton>
-                      </Tooltip>
-                      {!p.submissions.some((s) => s.type === 'start') && (
-                        <Button
-                          size="small"
-                          variant="outlined"
-                          startIcon={<AddIcon sx={{ fontSize: 16 }} />}
-                          onClick={() => openStartAuth(p)}
-                          sx={{ minHeight: 44, py: 0.75, px: 1.5, fontSize: '0.8125rem' }}
-                        >
-                          시작일 인증
-                        </Button>
-                      )}
-                      {!p.submissions.some((s) => s.type === 'end') && (() => {
-                        const handleEndClick = () => openEndAuth(p);
-                        const { main, glow } = getEndBtnColor(p.id);
-                        const glowDim = glow.replace('0.5)', '0.4)');
-                        return (
-                        <Button
-                          size="small"
-                          variant="outlined"
-                          startIcon={<AddIcon sx={{ fontSize: 16 }} />}
-                          onClick={handleEndClick}
-                          sx={{
-                            minHeight: 44,
-                            py: 0.75,
-                            px: 1.5,
-                            fontSize: '0.8125rem',
-                            position: 'relative',
-                            overflow: 'hidden',
-                            color: main,
-                            borderColor: main,
-                            '--end-glow': glow,
-                            '--end-glow-dim': glowDim,
-                            '&:hover': { borderColor: main, bgcolor: `${main}14` },
-                            animation: 'endBtnShimmer 2.5s ease-in-out infinite',
-                            '@keyframes endBtnShimmer': {
-                              '0%, 100%': { boxShadow: '0 0 0 0 var(--end-glow)' },
-                              '50%': { boxShadow: '0 0 16px 6px var(--end-glow-dim)' },
-                            },
-                            '&::before': {
-                              content: '""',
-                              position: 'absolute',
-                              top: 0,
-                              left: '-100%',
-                              width: '60%',
-                              height: '100%',
-                              background: 'linear-gradient(90deg, transparent, rgba(255,255,255,0.5), transparent)',
-                              animation: 'endBtnSparkle 2s ease-in-out infinite',
-                              zIndex: 0,
-                            },
-                            '@keyframes endBtnSparkle': {
-                              '0%': { left: '-100%' },
-                              '100%': { left: '140%' },
-                            },
-                          }}
-                        >
-                          종료일 인증
-                        </Button>
-                        );
-                      })()}
-                    </Box>
-                  </Box>
-                  <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5, mt: 1 }}>
-                    {[...p.submissions]
-                      .sort((a, b) => (a.type === 'start' ? 0 : 1) - (b.type === 'start' ? 0 : 1))
-                      .map((s) => {
-                        if (s.type === 'end' && !allEndComplete) {
-                          return (
-                            <Box key={s.id} sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                              <Typography variant="body2" color="text.secondary">
-                                종료: <span style={{ opacity: 0.7 }}>인증 완료</span>
-                              </Typography>
-                            </Box>
-                          );
-                        }
-                        return (
-                          <Box key={s.id} sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 1 }}>
-                            <Typography variant="body2" color="text.secondary" sx={{ flex: '1 1 auto', minWidth: 0 }}>
-                              {s.type === 'start' ? '시작' : '종료'}: 체지방률 <strong>{Number(s.body_fat_rate).toFixed(1)}%</strong>
-                            </Typography>
-                            {s.image_url ? (
-                              <Tooltip title="탭하여 이미지 보기">
-                                <Button
-                                  size="small"
-                                  variant="outlined"
-                                  color="primary"
-                                  startIcon={<PhotoCameraIcon sx={{ fontSize: 14 }} />}
-                                  sx={{ minHeight: 28, minWidth: 40, py: 0.25, px: 0.75, fontSize: '0.75rem', flexShrink: 0 }}
-                                  aria-label="인증 이미지 보기"
-                                  onClick={async () => {
-                                    // Sprint 0.3: storage path → signed URL (7일)
-                                    const url = await resolveImageUrl(s.image_url);
-                                    if (!url) {
-                                      setToast('이미지를 불러오지 못했습니다.');
-                                      return;
-                                    }
-                                    window.open(url, '_blank', 'noopener,noreferrer');
-                                  }}
-                                >
-                                  보기
-                                </Button>
-                              </Tooltip>
-                            ) : null}
-                          </Box>
-                        );
-                      })}
-                  </Box>
-                </CardContent>
-              </Card>
-            );
-          })}
-          {participants.length === 0 && (
-            <Typography color="text.secondary" sx={{ textAlign: 'center', py: 4 }}>
-              아직 참가자가 없습니다. 위에서 닉네임을 입력해 참가하세요.
-            </Typography>
-          )}
-        </Box>
+        <ParticipantsTab
+          participants={participants}
+          allEndComplete={allEndComplete}
+          onAuthStart={openStartAuth}
+          onAuthEnd={openEndAuth}
+          onOpenBasicInfo={(p) => setBasicInfo({ participant: p, afterJoin: false })}
+          onToast={setToast}
+        />
       )}
-
       {tab === 1 && (
-        <Box sx={{ px: 2, pt: 2 }}>
-          {/* 종료 인증 진행 상태 + 중간 순위 공개 토글 */}
-          {!allEndComplete && (
-            <Box
-              sx={{
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'space-between',
-                gap: 1,
-                mb: 2,
-                p: 1.5,
-                bgcolor: showRanking ? 'warning.50' : 'grey.50',
-                borderRadius: 1.5,
-                border: '1px solid',
-                borderColor: showRanking ? 'warning.200' : 'grey.200',
-              }}
-            >
-              <Box>
-                <Typography variant="body2" fontWeight={500}>
-                  종료 인증 {participantsWithStart.filter((p) =>
-                    p.submissions.some((s) => s.type === 'end')
-                  ).length} / {participantsWithStart.length}명 완료
-                </Typography>
-                <Typography variant="caption" color="text.secondary">
-                  {showRanking ? '현재 중간 순위 공개 중' : '전원 완료 시 자동 공개'}
-                </Typography>
-              </Box>
-              <Button
-                variant={showRanking ? 'contained' : 'outlined'}
-                size="small"
-                startIcon={showRanking ? <LockIcon /> : <LockOpenIcon />}
-                onClick={handleUnlockRanking}
-                color="warning"
-                sx={{ flexShrink: 0 }}
-              >
-                {showRanking ? '순위 잠금' : '중간 공개'}
-                {challenge?.has_admin_pin && (
-                  <LockIcon sx={{ fontSize: 12, ml: 0.5, opacity: 0.6 }} />
-                )}
-              </Button>
-            </Box>
-          )}
-          {!showRanking ? (
-            <Typography color="text.secondary" sx={{ textAlign: 'center', py: 6 }}>
-              종료 인증이 완료되면 순위가 공개됩니다.
-            </Typography>
-          ) : ranking.length === 0 ? (
-            <Typography color="text.secondary" sx={{ textAlign: 'center', py: 4 }}>
-              시작·종료 인증을 모두 마친 참가자가 있을 때 순위가 표시됩니다.
-            </Typography>
-          ) : (
-            <>
-              <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', mb: 2, gap: 1 }}>
-                <Box sx={{ p: 1.5, bgcolor: 'grey.50', borderRadius: 1.5, border: '1px solid', borderColor: 'grey.200', flex: 1 }}>
-                  <Typography variant="caption" color="text.secondary">
-                    💡 감소율 = (시작 − 종료) ÷ 시작 × 100
-                  </Typography>
-                  <Typography variant="caption" color="text.secondary" display="block" sx={{ mt: 0.25 }}>
-                    시작 체지방에 관계없이 공정하게 비교하는 상대 감소율입니다.
-                  </Typography>
-                </Box>
-                <Button
-                  variant="outlined"
-                  size="small"
-                  startIcon={<ShareIcon />}
-                  onClick={handleOpenRankingShare}
-                  sx={{ flexShrink: 0, minHeight: 44 }}
-                >
-                  결과 공유
-                </Button>
-              </Box>
-            <TableContainer component={Paper} sx={{ borderRadius: 2 }}>
-              <Table size="small" sx={{ tableLayout: 'fixed', width: '100%' }}>
-                <TableHead>
-                  <TableRow>
-                    <TableCell sx={{ width: 64, whiteSpace: 'nowrap' }}>순위</TableCell>
-                    <TableCell>닉네임</TableCell>
-                    <TableCell align="right" sx={{ width: 64 }}>시작</TableCell>
-                    <TableCell align="right" sx={{ width: 64 }}>종료</TableCell>
-                    <TableCell align="right" sx={{ width: 80 }}>
-                      <Tooltip title="감소율 = (시작 − 종료) ÷ 시작 × 100" arrow>
-                        <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5, cursor: 'help' }}>
-                          감소율
-                          <InfoOutlinedIcon sx={{ fontSize: 13, opacity: 0.55 }} />
-                        </Box>
-                      </Tooltip>
-                    </TableCell>
-                  </TableRow>
-                </TableHead>
-                <TableBody>
-                  {ranking.map((r) => {
-                    const medal = r.rank === 1 ? '🥇' : r.rank === 2 ? '🥈' : r.rank === 3 ? '🥉' : null;
-                    const isFirst = r.rank === 1;
-                    return (
-                      <TableRow
-                        key={r.nickname}
-                        sx={{
-                          ...(r.rank <= 3 ? { bgcolor: 'success.50' } : {}),
-                          ...(isFirst
-                            ? {
-                                background: [
-                                  'linear-gradient(90deg, transparent 0%, rgba(255,255,255,0.85) 20%, rgba(254,249,195,1) 50%, rgba(255,255,255,0.85) 80%, transparent 100%)',
-                                  'linear-gradient(135deg, #fef9c3 0%, #fef3c7 50%, #fde68a 100%)',
-                                ].join(', '),
-                                backgroundSize: '200% 100%, 100% 100%',
-                                backgroundPosition: '200% 0, 0 0',
-                                borderTop: '2px solid #f59e0b',
-                                borderBottom: '2px solid #f59e0b',
-                                boxShadow: '0 0 20px rgba(245, 158, 11, 0.4)',
-                                animation: 'rank1Shimmer 2s ease-in-out infinite, rank1Glow 1.8s ease-in-out infinite',
-                                '@keyframes rank1Shimmer': {
-                                  '0%': { backgroundPosition: '200% 0, 0 0' },
-                                  '100%': { backgroundPosition: '-200% 0, 0 0' },
-                                },
-                                '@keyframes rank1Glow': {
-                                  '0%, 100%': {
-                                    boxShadow: '0 0 20px rgba(245, 158, 11, 0.4), inset 0 0 30px rgba(254, 240, 138, 0.3)',
-                                    borderColor: '#f59e0b',
-                                  },
-                                  '50%': {
-                                    boxShadow: '0 0 30px rgba(245, 158, 11, 0.7), inset 0 0 50px rgba(254, 240, 138, 0.6)',
-                                    borderColor: '#fbbf24',
-                                  },
-                                },
-                              }
-                            : {}),
-                        }}
-                      >
-                        <TableCell sx={{ width: 64, verticalAlign: 'middle' }}>
-                          {medal ? (
-                            <Box
-                              component="span"
-                              role="img"
-                              aria-label={`${r.rank}위`}
-                              sx={{
-                                fontSize: 32,
-                                lineHeight: 1,
-                                filter: isFirst ? 'drop-shadow(0 0 6px rgba(245, 158, 11, 0.8))' : undefined,
-                                animation: isFirst ? 'rank1MedalTwinkle 1.5s ease-in-out infinite' : undefined,
-                                '@keyframes rank1MedalTwinkle': {
-                                  '0%, 100%': { filter: 'drop-shadow(0 0 6px rgba(245, 158, 11, 0.8))' },
-                                  '50%': { filter: 'drop-shadow(0 0 16px rgba(245, 158, 11, 1)) drop-shadow(0 0 8px rgba(254, 240, 138, 0.9))' },
-                                },
-                              }}
-                            >
-                              {medal}
-                            </Box>
-                          ) : (
-                            r.rank
-                          )}
-                        </TableCell>
-                        <TableCell
-                          sx={{
-                            fontWeight: r.rank === 1 ? 700 : 400,
-                            color: isFirst ? '#92400e' : 'inherit',
-                            verticalAlign: 'middle',
-                            overflow: 'hidden',
-                          }}
-                        >
-                          <Box sx={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                            {r.nickname}
-                          </Box>
-                        </TableCell>
-                        <TableCell align="right" sx={{ verticalAlign: 'middle' }}>{r.startBodyFat.toFixed(1)}%</TableCell>
-                        <TableCell align="right" sx={{ verticalAlign: 'middle' }}>{r.endBodyFat.toFixed(1)}%</TableCell>
-                        <TableCell align="right" sx={{ verticalAlign: 'middle' }}>
-                          <Typography
-                            component="span"
-                            sx={{
-                              color: isFirst ? '#b45309' : 'success.main',
-                              fontWeight: isFirst ? 700 : 600,
-                              textShadow: isFirst ? '0 0 8px rgba(245, 158, 11, 0.5)' : 'none',
-                            }}
-                          >
-                            -{r.reductionRate.toFixed(2)}%
-                          </Typography>
-                        </TableCell>
-                      </TableRow>
-                    );
-                  })}
-                </TableBody>
-              </Table>
-            </TableContainer>
-            </>
-          )}
-        </Box>
+        <RankingTab
+          ranking={ranking}
+          participants={participants}
+          challenge={challenge}
+          shareUrl={shareUrl}
+          onUnlockRanking={handleUnlockRanking}
+          onToast={setToast}
+        />
       )}
-
-      {tab === 2 && challenge && (
-        <Box sx={{ px: 2, pt: 2 }}>
-          <Box sx={{ mb: 2, p: 2, bgcolor: 'primary.50', borderRadius: 2, border: '1px solid', borderColor: 'primary.200' }}>
-            <Typography variant="body2" color="primary.dark" fontWeight={500}>
-              대결방 참가자 누구나 서로의 기록을 입력·확인할 수 있습니다.
-            </Typography>
-            <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
-              개인 락 없음 · 공동 입력 · 공동 확인
-            </Typography>
-          </Box>
-          {/* Sprint 2: 목표 진행률 위젯 — 식별된 "나" 에 대해 상단 고정 */}
-          {myParticipant && (
-            <GoalProgressWidget
-              participant={myParticipant}
-              logs={logsByParticipant[myParticipant.id] || []}
-              onOpenBasicInfo={() => { setBasicInfoDialog(myParticipant); setBasicInfoDialogAfterJoin(false); }}
-            />
-          )}
-          <RecordStatusSummary
-            currentWeek={recordStatus.currentWeek}
-            completedCount={recordStatus.completedCount}
-            notCompletedCount={recordStatus.notCompletedCount}
-            notCompleted={recordStatus.notCompleted}
-            cumulativeFillRate={recordStatus.cumulativeFillRate}
-            totalFilledCells={recordStatus.totalFilledCells}
-            totalPossibleCells={recordStatus.totalPossibleCells}
-          />
-          <Typography variant="subtitle2" sx={{ mb: 1 }}>
-            전체 참가자 추이
-          </Typography>
-          <AllParticipantsChart participants={participants} logsByParticipant={logsByParticipant} />
-          <Typography variant="subtitle2" sx={{ mt: 3, mb: 1 }}>
-            참가자별 상세
-          </Typography>
-          {participants.map((p) => (
-            <ParticipantWeeklyLogCard
-              key={p.id}
-              participant={p}
-              challengeStartDate={challenge.start_date}
-              challengeEndDate={challenge.end_date}
-              logs={logsByParticipant[p.id] || []}
-              onOpenLogForm={(weekNo) => setWeeklyLogTarget({ participant: p, defaultWeekNo: weekNo })}
-              onOpenBasicInfo={() => { setBasicInfoDialog(p); setBasicInfoDialogAfterJoin(false); }}
-              onRefresh={fetchParticipants}
-            />
-          ))}
-          {participants.length === 0 && (
-            <Typography color="text.secondary" sx={{ textAlign: 'center', py: 4 }}>
-              아직 참가자가 없습니다. 위에서 닉네임을 입력해 참가하세요.
-            </Typography>
-          )}
-        </Box>
-      )}
-
-      {submitModal && (
-        <SubmitModal
-          open={submitModal.open}
-          participantId={submitModal.participantId}
-          participantNickname={submitModal.participantNickname}
-          type={submitModal.type}
-          onClose={() => setSubmitModal(null)}
-          onSuccess={() => {
-            setSubmitModal(null);
-            fetchParticipants();
-          }}
+      {tab === 2 && (
+        <WeeklyLogsTab
+          challenge={challenge}
+          participants={participants}
+          logsByParticipant={logsByParticipant}
+          recordStatus={recordStatus}
+          myParticipant={myParticipant}
+          onOpenLogForm={openWeeklyLog}
+          onOpenBasicInfo={(p) => setBasicInfo({ participant: p, afterJoin: false })}
+          onRefresh={refetchParticipants}
         />
       )}
 
-      <WeeklyLogsUpgradeNoticeDialog
-        open={weeklyLogsNoticeOpen}
-        onClose={handleCloseWeeklyLogsNotice}
-      />
-
-      <Snackbar
-        open={snackbar}
-        autoHideDuration={2000}
-        onClose={() => setSnackbar(false)}
-        message="URL이 복사되었습니다"
-        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
-      />
-      <Snackbar
-        open={earlyEndBlockSnackbar}
-        autoHideDuration={4000}
-        onClose={() => setEarlyEndBlockSnackbar(false)}
-        message={`종료일(${endDateOnly || challenge.end_date}) 이후에 인증이 가능합니다.`}
-        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
-        sx={{ '& .MuiSnackbarContent-root': { bgcolor: 'warning.dark' } }}
-      />
-      <Snackbar
-        open={!!toast}
-        autoHideDuration={3000}
-        onClose={() => setToast(null)}
-        message={toast}
-        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
-      />
-
-      {/* 챌린지 기본정보 수정 다이얼로그 */}
-      <Dialog open={challengeEditOpen} onClose={() => setChallengeEditOpen(false)} maxWidth="sm" fullWidth>
-        <DialogTitle sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-          <EditIcon sx={{ fontSize: 20 }} />
-          챌린지 정보 수정
-        </DialogTitle>
-        <form onSubmit={handleChallengeEditSubmit}>
-          <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2, pt: 1 }}>
-            <TextField
-              fullWidth
-              label="대결 이름"
-              value={editTitle}
-              onChange={(e) => setEditTitle(e.target.value)}
-              required
-            />
-            <TextField
-              fullWidth
-              label="시작일"
-              type="date"
-              value={editStartDate}
-              onChange={(e) => setEditStartDate(e.target.value)}
-              InputLabelProps={{ shrink: true }}
-            />
-            <TextField
-              fullWidth
-              label="종료일"
-              type="date"
-              value={editEndDate}
-              onChange={(e) => setEditEndDate(e.target.value)}
-              InputLabelProps={{ shrink: true }}
-            />
-            <TextField
-              fullWidth
-              label="참가비 (원)"
-              type="number"
-              value={editStakeAmount}
-              onChange={(e) => setEditStakeAmount(Number(e.target.value) || 0)}
-              inputProps={{ min: 0 }}
-            />
-            {editError && (
-              <Typography color="error" variant="body2">
-                {editError}
-              </Typography>
-            )}
-          </DialogContent>
-          <DialogActions sx={{ px: 3, pb: 2 }}>
-            <Button onClick={() => setChallengeEditOpen(false)} color="inherit">취소</Button>
-            <Button type="submit" variant="contained" disabled={editLoading}>
-              {editLoading ? '저장 중...' : '저장'}
-            </Button>
-          </DialogActions>
-        </form>
-      </Dialog>
-
-      {/* PIN 확인 다이얼로그 */}
-      <Dialog open={pinDialog} onClose={() => setPinDialog(false)} maxWidth="xs" fullWidth>
-        <DialogTitle sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-          <LockIcon sx={{ fontSize: 20, color: 'warning.main' }} />
-          관리자 PIN 확인
-        </DialogTitle>
-        <DialogContent>
-          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-            {pendingPinAction === 'editChallenge'
-              ? '챌린지 정보 수정은 관리자 PIN이 필요합니다.'
-              : '순위 공개/잠금은 관리자 PIN이 필요합니다.'}
-          </Typography>
-          <TextField
-            fullWidth
-            label="PIN 4자리"
-            type="text"
-            inputProps={{ maxLength: 4, inputMode: 'numeric', pattern: '[0-9]*' }}
-            value={pinInput}
-            onChange={(e) => {
-              const v = e.target.value.replace(/\D/g, '').slice(0, 4);
-              setPinInput(v);
-              setPinError('');
-            }}
-            onKeyDown={(e) => { if (e.key === 'Enter' && !pinLoading) void handlePinSubmit(); }}
-            error={!!pinError}
-            helperText={pinError}
-            autoFocus
-            disabled={pinLoading}
-            InputProps={{
-              startAdornment: (
-                <InputAdornment position="start">
-                  <LockIcon sx={{ fontSize: 16, color: 'text.disabled' }} />
-                </InputAdornment>
-              ),
-            }}
-          />
-        </DialogContent>
-        <DialogActions sx={{ px: 3, pb: 2 }}>
-          <Button onClick={() => setPinDialog(false)} color="inherit" disabled={pinLoading}>
-            취소
-          </Button>
-          <Button
-            variant="contained"
-            color="warning"
-            onClick={() => void handlePinSubmit()}
-            disabled={pinLoading || pinInput.length !== 4}
-          >
-            {pinLoading ? '처리 중...' : '확인'}
-          </Button>
-        </DialogActions>
-      </Dialog>
-
-      {basicInfoDialog && (
-        <ParticipantBasicInfoDialog
-          open={!!basicInfoDialog}
-          participant={basicInfoDialog}
-          onClose={() => { setBasicInfoDialog(null); setBasicInfoDialogAfterJoin(false); }}
-          onSuccess={fetchParticipants}
-          isAfterJoin={basicInfoDialogAfterJoin}
-        />
-      )}
-
-      {weeklyLogTarget && challenge && (
-        <WeeklyLogForm
-          open={!!weeklyLogTarget}
-          participant={weeklyLogTarget.participant}
-          challengeStartDate={challenge.start_date}
-          challengeEndDate={challenge.end_date}
-          existingWeekNos={(logsByParticipant[weeklyLogTarget.participant.id] || []).map((l) => l.week_no)}
-          defaultWeekNo={weeklyLogTarget.defaultWeekNo}
-          onClose={() => setWeeklyLogTarget(null)}
-          onSuccess={() => {
-            fetchParticipants();
-            refetchLogs();
-          }}
-        />
-      )}
-
-      {/* Sprint 1: 종료 임박 모달 */}
-      <EndingSoonDialog
-        open={endingSoonOpen}
-        ddayLabel={dday.label}
-        endDate={endDateOnly || challenge.end_date}
-        myEndPending={myParticipant ? !myParticipant.submissions.some((s) => s.type === 'end') : undefined}
-        onClose={() => {
+      <ChallengeOverlays
+        challenge={challenge}
+        logsByParticipant={logsByParticipant}
+        myParticipant={myParticipant}
+        endDateOnly={endDateOnly}
+        dday={dday}
+        submitTarget={submitTarget}
+        onCloseSubmit={() => setSubmitTarget(null)}
+        onSubmitSuccess={() => {
+          setSubmitTarget(null);
+          refetchParticipants();
+        }}
+        basicInfo={basicInfo}
+        onCloseBasicInfo={() => setBasicInfo(null)}
+        onBasicInfoSuccess={refetchParticipants}
+        weeklyLogTarget={weeklyLogTarget}
+        onCloseWeeklyLog={() => setWeeklyLogTarget(null)}
+        onWeeklyLogSuccess={() => {
+          refetchParticipants();
+          refetchLogs();
+        }}
+        copySnackbar={copySnackbar}
+        onCloseCopy={() => setCopySnackbar(false)}
+        earlyEndSnackbar={earlyEndSnackbar}
+        onCloseEarlyEnd={() => setEarlyEndSnackbar(false)}
+        toast={toast}
+        onCloseToast={() => setToast(null)}
+        pinAction={pinAction}
+        onClosePin={() => setPinAction(null)}
+        onPinConfirmed={handlePinConfirmed}
+        editOpen={editOpen}
+        onCloseEdit={() => setEditOpen(false)}
+        onSavedEdit={(updated) => {
+          setChallenge(updated);
+          setToast('챌린지 정보가 수정되었습니다');
+        }}
+        endingSoonOpen={endingSoonOpen}
+        onCloseEndingSoon={() => {
           dismissEndingSoonNotice(challenge.id);
           setEndingSoonOpen(false);
         }}
-        onAuthEnd={myParticipant ? () => openEndAuth(myParticipant) : undefined}
+        onAuthEndMy={myParticipant ? () => openEndAuth(myParticipant) : undefined}
+        weeklyLogsNoticeOpen={weeklyLogsNoticeOpen}
+        onCloseWeeklyLogsNotice={() => {
+          dismissWeeklyLogsUpgradeNotice();
+          setWeeklyLogsNoticeOpen(false);
+        }}
       />
-
-      {/* Sprint 1: 랭킹 공유 (PNG + 텍스트) */}
-      {rankingShareOpen && (
-        <RankingShareDialog
-          open={rankingShareOpen}
-          challenge={challenge}
-          ranking={ranking}
-          participantCount={participants.length}
-          shareUrl={shareUrl}
-          onClose={() => setRankingShareOpen(false)}
-          onToast={(msg) => setToast(msg)}
-        />
-      )}
     </Box>
   );
 }

--- a/burnfat/src/theme/rankAnimations.ts
+++ b/burnfat/src/theme/rankAnimations.ts
@@ -1,0 +1,124 @@
+/**
+ * Sprint 3 Phase B — ChallengePage 의 인라인 sx keyframes 를 styled() 로 추출.
+ *
+ * 기존에는 종료 인증 버튼·1위 행·메달 애니메이션을 sx 안에 `@keyframes` 로
+ * 인라인 정의했다. 컴포넌트 분해 시 sx 중복을 막고, 한 곳에서
+ * `prefers-reduced-motion` 분기를 적용하기 위해 styled 컴포넌트로 옮긴다.
+ *
+ * 시각/동작은 기존과 동일하다. 단, CLAUDE.md §6 (prefers-reduced-motion 적용)
+ * 에 따라 reduce 설정 사용자에게는 데코 애니메이션을 정지시키는 분기를 추가했다.
+ */
+import { styled } from '@mui/material/styles';
+import Button from '@mui/material/Button';
+import TableRow from '@mui/material/TableRow';
+
+const REDUCED_MOTION = '@media (prefers-reduced-motion: reduce)';
+
+/**
+ * 종료일 인증 버튼 — 은은한 글로우 + 스파클 스윕.
+ * `glowMain` 은 참가자별 색, `glow`/`glowDim` 은 box-shadow 글로우 색.
+ */
+export const EndAuthButton = styled(Button, {
+  shouldForwardProp: (prop) =>
+    prop !== 'glowMain' && prop !== 'glow' && prop !== 'glowDim',
+})<{ glowMain: string; glow: string; glowDim: string }>(
+  ({ glowMain, glow, glowDim }) => ({
+    minHeight: 44,
+    paddingTop: 6,
+    paddingBottom: 6,
+    paddingLeft: 12,
+    paddingRight: 12,
+    fontSize: '0.8125rem',
+    position: 'relative',
+    overflow: 'hidden',
+    color: glowMain,
+    borderColor: glowMain,
+    '--end-glow': glow,
+    '--end-glow-dim': glowDim,
+    '&:hover': { borderColor: glowMain, backgroundColor: `${glowMain}14` },
+    animation: 'endBtnShimmer 2.5s ease-in-out infinite',
+    '@keyframes endBtnShimmer': {
+      '0%, 100%': { boxShadow: '0 0 0 0 var(--end-glow)' },
+      '50%': { boxShadow: '0 0 16px 6px var(--end-glow-dim)' },
+    },
+    '&::before': {
+      content: '""',
+      position: 'absolute',
+      top: 0,
+      left: '-100%',
+      width: '60%',
+      height: '100%',
+      background:
+        'linear-gradient(90deg, transparent, rgba(255,255,255,0.5), transparent)',
+      animation: 'endBtnSparkle 2s ease-in-out infinite',
+      zIndex: 0,
+    },
+    '@keyframes endBtnSparkle': {
+      '0%': { left: '-100%' },
+      '100%': { left: '140%' },
+    },
+    [REDUCED_MOTION]: {
+      animation: 'none',
+      '&::before': { animation: 'none', display: 'none' },
+    },
+  })
+);
+
+/** 순위표 1위 행 — 골드 셔머 + 글로우 펄스. */
+export const RankOneRow = styled(TableRow)({
+  background: [
+    'linear-gradient(90deg, transparent 0%, rgba(255,255,255,0.85) 20%, rgba(254,249,195,1) 50%, rgba(255,255,255,0.85) 80%, transparent 100%)',
+    'linear-gradient(135deg, #fef9c3 0%, #fef3c7 50%, #fde68a 100%)',
+  ].join(', '),
+  backgroundSize: '200% 100%, 100% 100%',
+  backgroundPosition: '200% 0, 0 0',
+  borderTop: '2px solid #f59e0b',
+  borderBottom: '2px solid #f59e0b',
+  boxShadow: '0 0 20px rgba(245, 158, 11, 0.4)',
+  animation: 'rank1Shimmer 2s ease-in-out infinite, rank1Glow 1.8s ease-in-out infinite',
+  '@keyframes rank1Shimmer': {
+    '0%': { backgroundPosition: '200% 0, 0 0' },
+    '100%': { backgroundPosition: '-200% 0, 0 0' },
+  },
+  '@keyframes rank1Glow': {
+    '0%, 100%': {
+      boxShadow:
+        '0 0 20px rgba(245, 158, 11, 0.4), inset 0 0 30px rgba(254, 240, 138, 0.3)',
+      borderColor: '#f59e0b',
+    },
+    '50%': {
+      boxShadow:
+        '0 0 30px rgba(245, 158, 11, 0.7), inset 0 0 50px rgba(254, 240, 138, 0.6)',
+      borderColor: '#fbbf24',
+    },
+  },
+  '@media (prefers-reduced-motion: reduce)': { animation: 'none' },
+});
+
+/**
+ * 순위표 메달(🥇/🥈/🥉) 컨테이너 — `<span>`.
+ * `twinkle` 가 true 일 때(1위) 드롭섀도 반짝임 애니메이션을 건다.
+ */
+export const RankMedal = styled('span', {
+  shouldForwardProp: (prop) => prop !== 'twinkle',
+})<{ twinkle?: boolean }>(({ twinkle }) => ({
+  fontSize: 32,
+  lineHeight: 1,
+  ...(twinkle
+    ? {
+        filter: 'drop-shadow(0 0 6px rgba(245, 158, 11, 0.8))',
+        animation: 'rank1MedalTwinkle 1.5s ease-in-out infinite',
+        '@keyframes rank1MedalTwinkle': {
+          '0%, 100%': { filter: 'drop-shadow(0 0 6px rgba(245, 158, 11, 0.8))' },
+          '50%': {
+            filter:
+              'drop-shadow(0 0 16px rgba(245, 158, 11, 1)) drop-shadow(0 0 8px rgba(254, 240, 138, 0.9))',
+          },
+        },
+        [REDUCED_MOTION]: {
+          animation: 'none',
+          filter: 'drop-shadow(0 0 6px rgba(245, 158, 11, 0.8))',
+        },
+      }
+    : {}),
+}));


### PR DESCRIPTION
## Summary
- **ChallengePage 분해**: `ChallengePage.tsx` 1,262줄 → 345줄(73%↓). `useChallengeData` 훅 + 신규 11개 파일로 책임 분리.
- **N+1 제거**: `participants.select('*, submissions(*)')` 임베드 — 진입 시 Supabase REST 호출 `2+N` → `3`건.
- **단위 테스트**: Vitest 48 → 79(신규 31) — useRecordStatus / useWeeklyLogs / useAIAdvice / useCoachSession / signedImage + deviceSecret 보강.
- 기능 보존 리팩터(동작 변경 0). DB·백엔드 무변경(프런트 전용).
- 의도된 변경 1건: rankAnimations 추출 시 prefers-reduced-motion 분기 추가(데코 애니메이션 한정).
- ⚠️ DoD ≤100줄 미달(345줄) — 탭 교차 8개 오버레이 모달 조율을 페이지에 보존. 상세: `docs/SPRINT3B_HANDOFF.md`.

## Test plan
- [x] `tsc --noEmit` 0 exit
- [x] `npm test` 79/79 통과
- [x] `npm run build` 성공
- [ ] 수동 회귀 6~8개: 진입 / 참가 / 시작·종료 인증 / 순위 / 주간 기록 / AI·코치 / 챌린지 수정
- [ ] DevTools Network: 진입 시 `rest/v1` 호출 3건 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)