### PR TITLE
fix(burnfat-coach): grok-4.3 400 회귀 — 페널티 파라미터 송신 토글

### DIFF
--- a/backend/routes/burnfat_coach.py
+++ b/backend/routes/burnfat_coach.py
@@ -54,6 +54,11 @@ DAILY_TOKENS_OUT_LIMIT = 10_000
 RECENT_TURNS = 12                  # 컨텍스트에 싣는 최근 턴 수
 MAX_INPUT_TOKENS = 6_000           # 입력 토큰 상한(추정) — 초과 시 오래된 턴부터 제거
 
+# xAI Grok 의 일부 모델(예: grok-4.3)은 OpenAI 호환 페널티 파라미터를
+# 받아들이지 않고 400 으로 거부한다. 디폴트는 미송신이며, 지원 모델로 운영할 때만
+# 환경변수 XAI_SEND_PENALTIES=1 로 명시 활성화한다.
+XAI_SEND_PENALTIES = os.environ.get("XAI_SEND_PENALTIES", "").lower() in {"1", "true", "yes"}
+
 VALID_PERSONAS = {"strict", "friendly", "scientist"}
 VALID_VISIBILITY = {"private", "room"}
 
@@ -429,22 +434,24 @@ def _stream_grok(
 ) -> Iterator[str]:
     """xAI chat.completions stream=true → content 토큰 조각을 yield.
 
-    반복 응답 완화를 위해 OpenAI 호환 페널티 파라미터를 함께 보낸다.
-    frequency_penalty/presence_penalty 는 일부 모델에서 무시될 수 있지만, 지원하는
-    모델에서는 같은 토큰·표현의 재등장 빈도를 낮춰준다.
+    OpenAI 호환 페널티 파라미터(frequency_penalty/presence_penalty)는 일부 xAI
+    모델(grok-4.3 등)이 400 으로 거부한다. 따라서 XAI_SEND_PENALTIES 환경변수가
+    켜진 경우에만 payload 에 포함한다 — 안티-반복은 시스템 프롬프트와 temperature
+    변주로 1차 방어한다.
     """
     api_key = os.environ.get("XAI_API_KEY")
     if not api_key:
         raise RuntimeError("XAI_API_KEY not configured")
-    payload = {
+    payload: dict[str, Any] = {
         "model": XAI_MODEL,
         "messages": messages,
         "max_tokens": max_tokens,
         "temperature": temperature,
-        "frequency_penalty": frequency_penalty,
-        "presence_penalty": presence_penalty,
         "stream": True,
     }
+    if XAI_SEND_PENALTIES:
+        payload["frequency_penalty"] = frequency_penalty
+        payload["presence_penalty"] = presence_penalty
     headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
     resp = requests.post(
         XAI_API_URL, json=payload, headers=headers, timeout=XAI_TIMEOUT_SECONDS, stream=True
@@ -609,6 +616,7 @@ def coach_health():
         # 환경변수가 잘못 설정된 것(INSERT 가 401 로 실패).
         "service_key_role": _service_key_role(),
         "model": XAI_MODEL,
+        "penalties_enabled": XAI_SEND_PENALTIES,
     }), 200
 
 


### PR DESCRIPTION
## 요약

[#17](https://github.com/Daesung-Kwon/wodybody/pull/17) 머지 직후 발생한 **프로덕션 회귀** 를 핫픽스합니다. 코치 모달에서 즉시 "AI 코치에 일시적으로 연결할 수 없어요" 표출.

## 원인

백엔드 로그(Railway):
```
Grok HTTP error 400 body={"code":"Client specified an invalid argument",
  "error":"Model grok-4.3 does not support parameter presencePenalty."}
```

[#17](https://github.com/Daesung-Kwon/wodybody/pull/17) 에서 `_stream_grok` payload 에 `frequency_penalty`/`presence_penalty` 를 *무조건* 포함하도록 했는데, 운영 모델 `grok-4.3` 은 두 파라미터를 무시(silently ignore) 가 아니라 **400 으로 reject** 함. 핸드오프 §2.E 의 "무시될 수 있다" 가정이 실측과 달랐음.

## 조치 (단일 파일 +14 / -6)

- 모듈 상수 `XAI_SEND_PENALTIES` (env var `XAI_SEND_PENALTIES`, 기본 `false`) 도입.
- `_stream_grok` payload 에 페널티 키를 *조건부*로만 포함.
- `/api/burnfat/coach/health` 응답에 `penalties_enabled` 필드 추가 — 운영 진단용.

## 영향

안티-반복 1차 방어선은 그대로 유지:
- `_COACH_SYSTEM` 의 5섹션 가이드(정형 도입/마무리/CTA 반복 금지, 식재료 카테고리 변주, 수량 표현 정확 충족)
- `<RECENT_ASSISTANT_PATTERNS>` (직전 3개 응답 도입/마무리 발췌 노출)
- `<VARIETY_DIRECTIVE>` / `<LIST_DIRECTIVE>` (변주·수량 키워드 감지 시 동적 주입)
- `temperature` 변주: 0.78 (변주 요청 시 0.9)

향후 페널티 지원 모델로 전환 시 Railway env 에 `XAI_SEND_PENALTIES=1` 설정.

## 배포 후 확인

```bash
curl -s https://wodybody-production.up.railway.app/api/burnfat/coach/health | jq
```
→ `penalties_enabled: false` 인지 확인. 그 후 코치 모달에서 평소 질문 1개 보내 응답 정상 수신 확인.

## Test plan
- [ ] Railway 자동 재배포 green
- [ ] `/coach/health` 200 + `penalties_enabled: false`
- [ ] 코치 모달 임의 질문 → SSE 응답 정상 (400 회귀 없음)
- [ ] 그 다음 [`COACH_PROMPT_HOTFIX_2026-05-20.md`](burnfat/docs/COACH_PROMPT_HOTFIX_2026-05-20.md) §6 스모크 4종 재시도

🤖 Generated with [Claude Code](https://claude.com/claude-code)