### PR TITLE
fix(burnfat-coach): 1주일치 응답 잘림 — max_tokens 900→1400

### DIFF
--- a/backend/routes/burnfat_coach.py
+++ b/backend/routes/burnfat_coach.py
@@ -853,10 +853,13 @@ def post_message():
     chat_messages.append({"role": "user", "content": content})
 
     # 변주·리스트 요청 시 다양성을 더 높이고, 리스트는 길이 상한도 키운다.
+    # 1주일치(7일×3끼=21항목) 같은 대형 리스트는 900 토큰이면 마지막 한 줄에서
+    # 잘리는 사례가 확인돼 1400 으로 상향. xAI grok-4.3 일일 출력 토큰 쿼터(10k)
+    # 대비 ~7회 분량이라 여유 있음.
     stream_temperature = 0.9 if variety_requested else 0.78
     stream_frequency_penalty = 0.6 if variety_requested else 0.35
     stream_presence_penalty = 0.5 if variety_requested else 0.2
-    stream_max_tokens = 900 if list_requested else ASSISTANT_MAX_TOKENS
+    stream_max_tokens = 1400 if list_requested else ASSISTANT_MAX_TOKENS
 
     def generate() -> Iterator[str]:
         yield _sse({


### PR DESCRIPTION
## 요약

PR [#18](https://github.com/Daesung-Kwon/wodybody/pull/18) 머지 후 첫 스모크에서 발견된 **응답 잘림** 증상을 핫픽스합니다.

## 증상

사용자가 "1주일치 다양한 식단" 류 요청 → 코치가 한식/양식/퓨전 **3 플랜 × 7일 × 3끼 = 21항목** 응답을 생성하다가 마지막 한 줄 `"어느 플랜이 더 끌…"` 에서 잘림.

내용·다양성·식재료 카테고리 변주는 정상 동작(주재료 겹침 0). 토큰 상한만 부족.

## 원인

[#17](https://github.com/Daesung-Kwon/wodybody/pull/17) 에서 `_wants_list=true` 분기에 `max_tokens=900` 부여했으나, 다중 플랜 × 주간 리스트 조합은 1,500+ 출력 토큰까지 가는 사례가 확인됨.

## 조치 (단일 파일 +4 / -1)

```diff
-    stream_max_tokens = 900 if list_requested else ASSISTANT_MAX_TOKENS
+    stream_max_tokens = 1400 if list_requested else ASSISTANT_MAX_TOKENS
```

- xAI grok-4.3 일일 출력 토큰 쿼터(10k) → 1400은 ~7회 분량으로 여유.
- 핸드오프 [`COACH_PROMPT_HOTFIX_2026-05-20.md`](burnfat/docs/COACH_PROMPT_HOTFIX_2026-05-20.md) §8 권장 상단(1200) 보다 200 더 — 다중 플랜 × 주간 요청 안전 마진.

## Test plan
- [ ] Railway 자동 재배포 green
- [ ] 코치 모달 → "1주일치 식단 추천해줘" → 마지막 마무리 문장까지 완전 수신
- [ ] 일반 질문(리스트 아님)은 여전히 600 토큰 상한 유지(불필요한 비용 증가 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)